### PR TITLE
Propagate Vivado target query failures

### DIFF
--- a/fpga/common/hw_target.py
+++ b/fpga/common/hw_target.py
@@ -56,6 +56,7 @@ def get_available_targets(vivado_path: str, remote_host: str = "") -> list[str]:
         capture_output=True,
         text=True,
     )
+    result.check_returncode()
 
     # Parse target list from stdout - look for lines starting with "TARGET:"
     targets = []

--- a/tests/test_hw_target.py
+++ b/tests/test_hw_target.py
@@ -1,0 +1,37 @@
+#    Copyright 2026 Two Sigma Open Source, LLC
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+
+"""Tests for FPGA hardware target selection."""
+
+import subprocess
+
+import pytest
+
+from fpga.common.hw_target import get_available_targets
+
+
+def test_get_available_targets_reports_vivado_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Report Vivado failures instead of treating them as an empty target list."""
+
+    def fail_vivado(
+        *args: object, **kwargs: object
+    ) -> subprocess.CompletedProcess[str]:
+        return subprocess.CompletedProcess(args=[], returncode=1, stdout="", stderr="")
+
+    monkeypatch.setattr(subprocess, "run", fail_vivado)
+
+    with pytest.raises(subprocess.CalledProcessError):
+        get_available_targets("vivado")


### PR DESCRIPTION
## Summary
- propagate a failed Vivado hardware-target query instead of treating it as an empty target list
- add a focused regression test for the non-zero exit path

## Why
`get_available_targets()` currently parses stdout regardless of Vivado's exit status. When Vivado cannot connect to `hw_server` or the TCL script fails, the caller falls through to the generic "No hardware targets found" message and suggests checking JTAG wiring or board power. Propagating the subprocess failure preserves the distinction between an empty successful query and a failed query.

## Validation
- `git diff --check`
- `python3 -m compileall -q fpga/common/hw_target.py tests/test_hw_target.py`
- `python -m pytest tests/test_hw_target.py`