### PR TITLE
 test: add slot-2 LQ/SQ cocotb coverage

### DIFF
--- a/hw/rtl/cpu_and_mem/cpu/tomasulo/load_queue/README.md
+++ b/hw/rtl/cpu_and_mem/cpu/tomasulo/load_queue/README.md
@@ -143,9 +143,8 @@ still live alongside the decomposition.
 
 ## Verification
 
-Cocotb tests cover allocation (slot-1; the slot-2 alloc port is held
-inactive and not yet exercised), address update, every load size, SQ
-forwarding, MMIO ordering, FLD two-phase, FLW NaN-boxing, partial and
-full flush, AMO read-modify-write, LR/SC reservation, and
-constrained-random stress. Inline formal properties prove pointer invariants,
-issue prerequisites, MMIO ordering, and flush behavior.
+Cocotb tests cover allocation including slot-2-only and paired slot-1/slot-2
+cases, address update, every load size, SQ forwarding, MMIO ordering, FLD
+two-phase, FLW NaN-boxing, partial and full flush, AMO read-modify-write,
+LR/SC reservation, and constrained-random stress. Inline formal properties prove
+pointer invariants, issue prerequisites, MMIO ordering, and flush behavior.

--- a/hw/rtl/cpu_and_mem/cpu/tomasulo/register_alias_table/README.md
+++ b/hw/rtl/cpu_and_mem/cpu/tomasulo/register_alias_table/README.md
@@ -80,11 +80,11 @@ gets reclaimed without going through the per-slot port.
 
 ## Verification
 
-Cocotb tests cover lookup, rename (including overwrite and rename-over-commit
-precedence), commit clear, checkpoint save/restore/free, checkpoint exhaustion,
-flush-all, regfile value passthrough, and x0 invariants. (The slot-2 rename,
-slot-2 commit, and bulk-free mask ports are exercised by integration tests, not
-the unit suite, which holds them at zero.) Inline formal properties prove the x0
+Cocotb tests cover lookup, slot-2 lookup, rename (including overwrite,
+slot-2 rename, slot-2-wins collisions, and rename-over-commit precedence),
+slot-1/slot-2 commit clear, checkpoint save/restore/free, slot-2 checkpoint
+overlay, checkpoint bulk-free masks, checkpoint exhaustion, flush-all, regfile
+value passthrough, and x0 invariants. Inline formal properties prove the x0
 invariant, the slot-1 and slot-2 rename state transitions, the commit-clear
 state transition, and that flush/reset clear the active RATs and checkpoint
 valid bits.

--- a/hw/rtl/cpu_and_mem/cpu/tomasulo/reservation_station/README.md
+++ b/hw/rtl/cpu_and_mem/cpu/tomasulo/reservation_station/README.md
@@ -82,9 +82,8 @@ elsewhere in the back-end. Older entries are preserved.
 
 ## Verification
 
-Cocotb tests cover dispatch, CDB wakeup for each source
-slot, same-cycle bypass, issue priority, FU ready gating, immediate bypass, and
-partial/full flush. The cocotb bench drives only slot 1 (slot-2 dispatch and
-`i_intent_1` are tied off), so 2-wide allocation is exercised in formal instead:
-inline formal properties prove the dispatch / issue / wakeup / flush invariants
-and cover both-slots and slot-2-alone dispatch.
+Cocotb tests cover dispatch, slot-2-only dispatch, same-cycle slot-1/slot-2
+dispatch, CDB wakeup for each source slot, same-cycle bypass, slot-2 CDB bypass,
+issue priority, FU ready gating, immediate bypass, `full_for_2` gating, and
+partial/full flush. Inline formal properties also prove the dispatch / issue /
+wakeup / flush invariants and cover both-slots and slot-2-alone dispatch.

--- a/verif/cocotb_tests/tomasulo/dispatch/dispatch_interface.py
+++ b/verif/cocotb_tests/tomasulo/dispatch/dispatch_interface.py
@@ -1202,17 +1202,14 @@ class DispatchInterface:
         """Initialize all input signals to safe defaults."""
         self.dut.i_from_id_to_ex.value = 0
         self.dut.i_valid.value = 0
-        # Slot-2 instruction (2-wide dispatch).  Held inactive in the
-        # dispatch unit tests; slot-2 dispatch is hard-tied off until later
-        # sessions wire it through cpu_ooo.
+        # Slot-2 instruction (2-wide dispatch).  Default inactive; tests that
+        # exercise 2-wide behavior drive it explicitly.
         self.dut.i_from_id_to_ex_2.value = 0
         self.dut.i_valid_2.value = 0
         self.dut.i_rs1_addr.value = 0
         self.dut.i_rs2_addr.value = 0
         self.dut.i_fp_rs3_addr.value = 0
-        # Slot-2 source register addresses (2-wide dispatch).  Held at zero
-        # in the dispatch unit tests; slot-2 dispatch is hard-tied off until
-        # later sessions wire in slot-2 instruction inputs.
+        # Slot-2 source register addresses (2-wide dispatch).
         self.dut.i_rs1_addr_2.value = 0
         self.dut.i_rs2_addr_2.value = 0
         self.dut.i_fp_rs3_addr_2.value = 0
@@ -1244,9 +1241,7 @@ class DispatchInterface:
         self.dut.i_fdiv_rs_full.value = 0
         self.dut.i_lq_full.value = 0
         self.dut.i_sq_full.value = 0
-        # Slot-2 "room for 2" status inputs.  Held at zero in unit tests
-        # (room for 2 always available).  Slot-2 dispatch fire gates use
-        # these but never assert until cpu_ooo wires up slot-2 instructions.
+        # Slot-2 "room for 2" status inputs.  Default to room available.
         self.dut.i_rob_full_for_2.value = 0
         self.dut.i_int_rs_full_for_2.value = 0
         self.dut.i_mul_rs_full_for_2.value = 0
@@ -1287,6 +1282,26 @@ class DispatchInterface:
         self.dut.i_valid.value = 0
         self.dut.i_from_id_to_ex.value = 0
 
+    def drive_instruction_2(
+        self,
+        valid: bool = True,
+        rs1_addr: int = 0,
+        rs2_addr: int = 0,
+        fp_rs3_addr: int = 0,
+        **kwargs: int,
+    ) -> None:
+        """Drive the slot-2 instruction input and associated signals."""
+        self.dut.i_valid_2.value = 1 if valid else 0
+        self.dut.i_rs1_addr_2.value = rs1_addr & 0x1F
+        self.dut.i_rs2_addr_2.value = rs2_addr & 0x1F
+        self.dut.i_fp_rs3_addr_2.value = fp_rs3_addr & 0x1F
+        self.dut.i_from_id_to_ex_2.value = build_from_id_to_ex(**kwargs)
+
+    def clear_instruction_2(self) -> None:
+        """De-assert slot-2 instruction valid and zero out inputs."""
+        self.dut.i_valid_2.value = 0
+        self.dut.i_from_id_to_ex_2.value = 0
+
     # =========================================================================
     # FRM CSR
     # =========================================================================
@@ -1304,6 +1319,14 @@ class DispatchInterface:
     ) -> None:
         """Drive the ROB allocation response input."""
         self.dut.i_rob_alloc_resp.value = pack_rob_alloc_resp(
+            alloc_ready=alloc_ready, alloc_tag=alloc_tag, full=full
+        )
+
+    def drive_rob_alloc_resp_2(
+        self, alloc_ready: int = 1, alloc_tag: int = 0, full: int = 0
+    ) -> None:
+        """Drive the slot-2 ROB allocation response input."""
+        self.dut.i_rob_alloc_resp_2.value = pack_rob_alloc_resp(
             alloc_ready=alloc_ready, alloc_tag=alloc_tag, full=full
         )
 
@@ -1330,6 +1353,26 @@ class DispatchInterface:
     def drive_fp_src3(self, renamed: int = 0, tag: int = 0, value: int = 0) -> None:
         """Drive FP source 3 RAT lookup result."""
         self.dut.i_fp_src3.value = pack_rat_lookup(renamed, tag, value)
+
+    def drive_int_src1_2(self, renamed: int = 0, tag: int = 0, value: int = 0) -> None:
+        """Drive slot-2 integer source 1 RAT lookup result."""
+        self.dut.i_int_src1_2.value = pack_rat_lookup(renamed, tag, value)
+
+    def drive_int_src2_2(self, renamed: int = 0, tag: int = 0, value: int = 0) -> None:
+        """Drive slot-2 integer source 2 RAT lookup result."""
+        self.dut.i_int_src2_2.value = pack_rat_lookup(renamed, tag, value)
+
+    def drive_fp_src1_2(self, renamed: int = 0, tag: int = 0, value: int = 0) -> None:
+        """Drive slot-2 FP source 1 RAT lookup result."""
+        self.dut.i_fp_src1_2.value = pack_rat_lookup(renamed, tag, value)
+
+    def drive_fp_src2_2(self, renamed: int = 0, tag: int = 0, value: int = 0) -> None:
+        """Drive slot-2 FP source 2 RAT lookup result."""
+        self.dut.i_fp_src2_2.value = pack_rat_lookup(renamed, tag, value)
+
+    def drive_fp_src3_2(self, renamed: int = 0, tag: int = 0, value: int = 0) -> None:
+        """Drive slot-2 FP source 3 RAT lookup result."""
+        self.dut.i_fp_src3_2.value = pack_rat_lookup(renamed, tag, value)
 
     # =========================================================================
     # Resource Status
@@ -1371,6 +1414,42 @@ class DispatchInterface:
         """Set SQ full signal."""
         self.dut.i_sq_full.value = 1 if full else 0
 
+    def set_rob_full_for_2(self, full: bool) -> None:
+        """Set ROB room-for-2 full signal."""
+        self.dut.i_rob_full_for_2.value = 1 if full else 0
+
+    def set_int_rs_full_for_2(self, full: bool) -> None:
+        """Set INT RS room-for-2 full signal."""
+        self.dut.i_int_rs_full_for_2.value = 1 if full else 0
+
+    def set_mul_rs_full_for_2(self, full: bool) -> None:
+        """Set MUL RS room-for-2 full signal."""
+        self.dut.i_mul_rs_full_for_2.value = 1 if full else 0
+
+    def set_mem_rs_full_for_2(self, full: bool) -> None:
+        """Set MEM RS room-for-2 full signal."""
+        self.dut.i_mem_rs_full_for_2.value = 1 if full else 0
+
+    def set_fp_rs_full_for_2(self, full: bool) -> None:
+        """Set FP RS room-for-2 full signal."""
+        self.dut.i_fp_rs_full_for_2.value = 1 if full else 0
+
+    def set_fmul_rs_full_for_2(self, full: bool) -> None:
+        """Set FMUL RS room-for-2 full signal."""
+        self.dut.i_fmul_rs_full_for_2.value = 1 if full else 0
+
+    def set_fdiv_rs_full_for_2(self, full: bool) -> None:
+        """Set FDIV RS room-for-2 full signal."""
+        self.dut.i_fdiv_rs_full_for_2.value = 1 if full else 0
+
+    def set_lq_full_for_2(self, full: bool) -> None:
+        """Set LQ room-for-2 full signal."""
+        self.dut.i_lq_full_for_2.value = 1 if full else 0
+
+    def set_sq_full_for_2(self, full: bool) -> None:
+        """Set SQ room-for-2 full signal."""
+        self.dut.i_sq_full_for_2.value = 1 if full else 0
+
     # =========================================================================
     # Checkpoint
     # =========================================================================
@@ -1407,9 +1486,61 @@ class DispatchInterface:
         """Read and unpack o_rob_alloc_req."""
         return unpack_rob_alloc_req(int(self.dut.o_rob_alloc_req.value))
 
+    def read_rob_alloc_req_2(self) -> dict[str, int]:
+        """Read and unpack o_rob_alloc_req_2."""
+        return unpack_rob_alloc_req(int(self.dut.o_rob_alloc_req_2.value))
+
     def read_rs_dispatch(self) -> dict[str, int]:
         """Read and unpack o_rs_dispatch."""
         return unpack_rs_dispatch(int(self.dut.o_rs_dispatch.value))
+
+    def read_int_rs_dispatch(self) -> dict[str, int]:
+        """Read and unpack o_int_rs_dispatch."""
+        return unpack_rs_dispatch(int(self.dut.o_int_rs_dispatch.value))
+
+    def read_mul_rs_dispatch(self) -> dict[str, int]:
+        """Read and unpack o_mul_rs_dispatch."""
+        return unpack_rs_dispatch(int(self.dut.o_mul_rs_dispatch.value))
+
+    def read_mem_rs_dispatch(self) -> dict[str, int]:
+        """Read and unpack o_mem_rs_dispatch."""
+        return unpack_rs_dispatch(int(self.dut.o_mem_rs_dispatch.value))
+
+    def read_fp_rs_dispatch(self) -> dict[str, int]:
+        """Read and unpack o_fp_rs_dispatch."""
+        return unpack_rs_dispatch(int(self.dut.o_fp_rs_dispatch.value))
+
+    def read_fmul_rs_dispatch(self) -> dict[str, int]:
+        """Read and unpack o_fmul_rs_dispatch."""
+        return unpack_rs_dispatch(int(self.dut.o_fmul_rs_dispatch.value))
+
+    def read_fdiv_rs_dispatch(self) -> dict[str, int]:
+        """Read and unpack o_fdiv_rs_dispatch."""
+        return unpack_rs_dispatch(int(self.dut.o_fdiv_rs_dispatch.value))
+
+    def read_int_rs_dispatch_2(self) -> dict[str, int]:
+        """Read and unpack o_int_rs_dispatch_2."""
+        return unpack_rs_dispatch(int(self.dut.o_int_rs_dispatch_2.value))
+
+    def read_mul_rs_dispatch_2(self) -> dict[str, int]:
+        """Read and unpack o_mul_rs_dispatch_2."""
+        return unpack_rs_dispatch(int(self.dut.o_mul_rs_dispatch_2.value))
+
+    def read_mem_rs_dispatch_2(self) -> dict[str, int]:
+        """Read and unpack o_mem_rs_dispatch_2."""
+        return unpack_rs_dispatch(int(self.dut.o_mem_rs_dispatch_2.value))
+
+    def read_fp_rs_dispatch_2(self) -> dict[str, int]:
+        """Read and unpack o_fp_rs_dispatch_2."""
+        return unpack_rs_dispatch(int(self.dut.o_fp_rs_dispatch_2.value))
+
+    def read_fmul_rs_dispatch_2(self) -> dict[str, int]:
+        """Read and unpack o_fmul_rs_dispatch_2."""
+        return unpack_rs_dispatch(int(self.dut.o_fmul_rs_dispatch_2.value))
+
+    def read_fdiv_rs_dispatch_2(self) -> dict[str, int]:
+        """Read and unpack o_fdiv_rs_dispatch_2."""
+        return unpack_rs_dispatch(int(self.dut.o_fdiv_rs_dispatch_2.value))
 
     @property
     def stall(self) -> bool:
@@ -1437,9 +1568,34 @@ class DispatchInterface:
         return int(self.dut.o_rat_alloc_rob_tag.value)
 
     @property
+    def rat_alloc_valid_2(self) -> bool:
+        """Read o_rat_alloc_valid_2 output."""
+        return bool(self.dut.o_rat_alloc_valid_2.value)
+
+    @property
+    def rat_alloc_dest_rf_2(self) -> int:
+        """Read o_rat_alloc_dest_rf_2 output (0=INT, 1=FP)."""
+        return int(self.dut.o_rat_alloc_dest_rf_2.value)
+
+    @property
+    def rat_alloc_dest_reg_2(self) -> int:
+        """Read o_rat_alloc_dest_reg_2 output."""
+        return int(self.dut.o_rat_alloc_dest_reg_2.value)
+
+    @property
+    def rat_alloc_rob_tag_2(self) -> int:
+        """Read o_rat_alloc_rob_tag_2 output."""
+        return int(self.dut.o_rat_alloc_rob_tag_2.value)
+
+    @property
     def checkpoint_save(self) -> bool:
         """Read o_checkpoint_save output."""
         return bool(self.dut.o_checkpoint_save.value)
+
+    @property
+    def checkpoint_save_for_slot2(self) -> bool:
+        """Read o_checkpoint_save_for_slot2 output."""
+        return bool(self.dut.o_checkpoint_save_for_slot2.value)
 
     @property
     def checkpoint_id(self) -> int:

--- a/verif/cocotb_tests/tomasulo/dispatch/test_dispatch.py
+++ b/verif/cocotb_tests/tomasulo/dispatch/test_dispatch.py
@@ -80,6 +80,7 @@ async def _setup(dut: Any) -> DispatchInterface:
     await dut_if.reset_dut(cycles=5)
     # Provide a default ROB alloc response: ready, tag=0, not full
     dut_if.drive_rob_alloc_resp(alloc_ready=1, alloc_tag=0, full=0)
+    dut_if.drive_rob_alloc_resp_2(alloc_ready=1, alloc_tag=1, full=0)
     # Default: checkpoint available
     dut_if.drive_checkpoint(available=True, alloc_id=0)
     return dut_if
@@ -418,6 +419,345 @@ async def test_source_not_ready_renamed(dut: Any) -> None:
     assert rs["src1_ready"] == 0, "src1 should not be ready (renamed)"
     assert rs["src1_tag"] == 7, f"src1_tag mismatch: {rs['src1_tag']}"
     assert rs["src2_ready"] == 1, "src2 should be ready"
+
+
+# =============================================================================
+# Slot-2 Bundle Tests
+# =============================================================================
+
+
+@cocotb.test()
+async def test_slot2_dual_int_dispatches_and_renames(dut: Any) -> None:
+    """Slot 1 and slot 2 can dispatch integer ops in one cycle."""
+    dut_if = await _setup(dut)
+
+    dut_if.drive_rob_alloc_resp(alloc_ready=1, alloc_tag=6, full=0)
+    dut_if.drive_rob_alloc_resp_2(alloc_ready=1, alloc_tag=7, full=0)
+    dut_if.drive_int_src1(renamed=0, tag=0, value=0x11)
+    dut_if.drive_int_src2(renamed=0, tag=0, value=0x22)
+    dut_if.drive_int_src1_2(renamed=0, tag=0, value=0x33)
+
+    dut_if.drive_instruction(
+        valid=True,
+        rs1_addr=1,
+        rs2_addr=2,
+        instruction_operation=ADD,
+        program_counter=0x1000,
+        instruction=_make_instr(
+            dest_reg=5,
+            opcode=OPC_OP,
+            source_reg_1=1,
+            source_reg_2=2,
+        ),
+    )
+    dut_if.drive_instruction_2(
+        valid=True,
+        rs1_addr=3,
+        instruction_operation=ADDI,
+        immediate_i_type=12,
+        program_counter=0x1004,
+        instruction=_make_instr(
+            dest_reg=6,
+            opcode=OPC_OP_IMM,
+            source_reg_1=3,
+        ),
+    )
+    await dut_if.step()
+
+    assert not dut_if.stall, "Dual integer bundle should fire"
+    req1 = dut_if.read_rob_alloc_req()
+    req2 = dut_if.read_rob_alloc_req_2()
+    assert req1["alloc_valid"] == 1, "Slot 1 should allocate ROB"
+    assert req2["alloc_valid"] == 1, "Slot 2 should allocate ROB"
+    assert req2["pc"] == 0x1004
+    assert req2["dest_valid"] == 1
+    assert req2["dest_reg"] == 6
+
+    assert dut_if.rat_alloc_valid, "Slot 1 should rename x5"
+    assert dut_if.rat_alloc_dest_reg == 5
+    assert dut_if.rat_alloc_rob_tag == 6
+    assert dut_if.rat_alloc_valid_2, "Slot 2 should rename x6"
+    assert dut_if.rat_alloc_dest_reg_2 == 6
+    assert dut_if.rat_alloc_rob_tag_2 == 7
+
+    slot1_rs = dut_if.read_int_rs_dispatch()
+    slot2_rs = dut_if.read_int_rs_dispatch_2()
+    assert slot1_rs["valid"] == 1
+    assert slot1_rs["rs_type"] == RS_INT
+    assert slot1_rs["rob_tag"] == 6
+    assert slot2_rs["valid"] == 1
+    assert slot2_rs["rs_type"] == RS_INT
+    assert slot2_rs["rob_tag"] == 7
+    assert slot2_rs["use_imm"] == 1
+    assert slot2_rs["imm"] == 12
+    assert slot2_rs["src1_ready"] == 1
+    assert slot2_rs["src1_value"] == 0x33
+
+
+@cocotb.test()
+async def test_slot2_raw_source_uses_slot1_rob_tag(dut: Any) -> None:
+    """Slot-2 source matching slot-1 dest should use slot-1's ROB tag."""
+    dut_if = await _setup(dut)
+
+    dut_if.drive_rob_alloc_resp(alloc_ready=1, alloc_tag=12, full=0)
+    dut_if.drive_rob_alloc_resp_2(alloc_ready=1, alloc_tag=13, full=0)
+    dut_if.drive_int_src1_2(renamed=0, tag=0, value=0xCAFE)
+
+    dut_if.drive_instruction(
+        valid=True,
+        instruction_operation=ADD,
+        instruction=_make_instr(dest_reg=9, opcode=OPC_OP),
+    )
+    dut_if.drive_instruction_2(
+        valid=True,
+        rs1_addr=9,
+        instruction_operation=ADDI,
+        immediate_i_type=1,
+        instruction=_make_instr(dest_reg=10, opcode=OPC_OP_IMM, source_reg_1=9),
+    )
+    await dut_if.step()
+
+    assert not dut_if.stall
+    slot2_rs = dut_if.read_int_rs_dispatch_2()
+    assert slot2_rs["valid"] == 1
+    assert slot2_rs["src1_ready"] == 0, "RAW source should wait on slot-1 tag"
+    assert slot2_rs["src1_tag"] == 12, f"Expected tag 12, got {slot2_rs['src1_tag']}"
+
+
+@cocotb.test()
+async def test_slot2_same_rs_full_for_2_stalls_bundle(dut: Any) -> None:
+    """Same-RS bundles should stall when the room-for-2 signal is full."""
+    dut_if = await _setup(dut)
+
+    dut_if.set_int_rs_full_for_2(True)
+    dut_if.drive_instruction(
+        valid=True,
+        instruction_operation=ADD,
+        instruction=_make_instr(dest_reg=5, opcode=OPC_OP),
+    )
+    dut_if.drive_instruction_2(
+        valid=True,
+        instruction_operation=ADDI,
+        instruction=_make_instr(dest_reg=6, opcode=OPC_OP_IMM),
+    )
+    await dut_if.step()
+
+    assert dut_if.stall, "INT/INT bundle should stall when INT RS lacks room for 2"
+    assert dut_if.read_rob_alloc_req()["alloc_valid"] == 0
+    assert dut_if.read_rob_alloc_req_2()["alloc_valid"] == 0
+    assert dut_if.read_int_rs_dispatch()["valid"] == 0
+    assert dut_if.read_int_rs_dispatch_2()["valid"] == 0
+
+
+@cocotb.test()
+async def test_slot2_different_rs_ignores_unrelated_full_for_2(dut: Any) -> None:
+    """Different-RS bundles should use plain fullness for the slot-2 RS."""
+    dut_if = await _setup(dut)
+
+    dut_if.drive_rob_alloc_resp(alloc_ready=1, alloc_tag=4, full=0)
+    dut_if.drive_rob_alloc_resp_2(alloc_ready=1, alloc_tag=5, full=0)
+    dut_if.set_int_rs_full_for_2(True)
+    dut_if.set_mul_rs_full_for_2(True)
+
+    dut_if.drive_instruction(
+        valid=True,
+        instruction_operation=ADD,
+        instruction=_make_instr(dest_reg=5, opcode=OPC_OP),
+    )
+    dut_if.drive_instruction_2(
+        valid=True,
+        instruction_operation=MUL,
+        instruction=_make_instr(dest_reg=6, opcode=OPC_OP),
+    )
+    await dut_if.step()
+
+    assert not dut_if.stall, "INT/MUL should ignore unrelated room-for-2 flags"
+    slot1_rs = dut_if.read_int_rs_dispatch()
+    slot2_rs = dut_if.read_mul_rs_dispatch_2()
+    assert slot1_rs["valid"] == 1
+    assert slot2_rs["valid"] == 1
+    assert slot2_rs["rs_type"] == RS_MUL
+    assert slot2_rs["rob_tag"] == 5
+
+
+@cocotb.test()
+async def test_slot1_branch_blocks_slot2_bundle(dut: Any) -> None:
+    """Slot 1 control flow should terminate the bundle before slot 2 fires."""
+    dut_if = await _setup(dut)
+
+    dut_if.drive_checkpoint(available=True, alloc_id=3)
+    dut_if.drive_instruction(
+        valid=True,
+        rs1_addr=1,
+        rs2_addr=2,
+        instruction_operation=BEQ,
+        instruction=_make_instr(
+            opcode=OPC_BRANCH,
+            source_reg_1=1,
+            source_reg_2=2,
+        ),
+    )
+    dut_if.drive_instruction_2(
+        valid=True,
+        instruction_operation=ADD,
+        instruction=_make_instr(dest_reg=5, opcode=OPC_OP),
+    )
+    await dut_if.step()
+
+    assert dut_if.stall, "Slot-1 branch with valid slot 2 should stall the bundle"
+    assert dut_if.read_rob_alloc_req()["alloc_valid"] == 0
+    assert dut_if.read_rob_alloc_req_2()["alloc_valid"] == 0
+    assert not dut_if.checkpoint_save
+    assert dut_if.read_int_rs_dispatch()["valid"] == 0
+    assert dut_if.read_int_rs_dispatch_2()["valid"] == 0
+
+
+@cocotb.test()
+async def test_slot2_branch_saves_slot2_checkpoint(dut: Any) -> None:
+    """Slot-2 branches should save a checkpoint using slot-2 metadata."""
+    dut_if = await _setup(dut)
+
+    dut_if.drive_checkpoint(available=True, alloc_id=5)
+    dut_if.drive_rob_alloc_resp(alloc_ready=1, alloc_tag=2, full=0)
+    dut_if.drive_rob_alloc_resp_2(alloc_ready=1, alloc_tag=3, full=0)
+    dut_if.drive_instruction(
+        valid=True,
+        instruction_operation=ADD,
+        instruction=_make_instr(dest_reg=8, opcode=OPC_OP),
+    )
+    dut_if.drive_instruction_2(
+        valid=True,
+        rs1_addr=1,
+        rs2_addr=2,
+        instruction_operation=BEQ,
+        program_counter=0x2004,
+        branch_target_precomputed=0x2080,
+        btb_predicted_taken=1,
+        btb_predicted_target=0x2070,
+        ras_checkpoint_tos=6,
+        ras_checkpoint_valid_count=7,
+        instruction=_make_instr(
+            opcode=OPC_BRANCH,
+            source_reg_1=1,
+            source_reg_2=2,
+        ),
+    )
+    await dut_if.step()
+
+    assert not dut_if.stall
+    req2 = dut_if.read_rob_alloc_req_2()
+    assert req2["alloc_valid"] == 1
+    assert req2["is_branch"] == 1
+    assert req2["branch_target"] == 0x2080
+    assert req2["predicted_taken"] == 1
+    assert req2["predicted_target"] == 0x2070
+
+    assert dut_if.checkpoint_save, "Slot-2 branch should save checkpoint"
+    assert dut_if.checkpoint_save_for_slot2
+    assert dut_if.checkpoint_id == 5
+    assert dut_if.checkpoint_branch_tag == 3
+    assert dut_if.ras_tos_out == 6
+    assert dut_if.ras_valid_count_out == 7
+    assert dut_if.rob_checkpoint_valid
+    assert dut_if.rob_checkpoint_id == 5
+
+    slot2_rs = dut_if.read_int_rs_dispatch_2()
+    assert slot2_rs["valid"] == 1
+    assert slot2_rs["has_checkpoint"] == 1
+    assert slot2_rs["checkpoint_id"] == 5
+
+
+@cocotb.test()
+async def test_slot2_fp_compute_serializes_off(dut: Any) -> None:
+    """Slot-2 FP compute ops should not allocate while slot 1 fires."""
+    dut_if = await _setup(dut)
+
+    dut_if.drive_instruction(
+        valid=True,
+        instruction_operation=ADD,
+        instruction=_make_instr(dest_reg=5, opcode=OPC_OP),
+    )
+    dut_if.drive_instruction_2(
+        valid=True,
+        instruction_operation=FADD_S,
+        instruction=_make_instr(dest_reg=3, opcode=OPC_OP_FP),
+    )
+    await dut_if.step()
+
+    assert not dut_if.stall, "Serialized slot-2 FP op should not block slot 1"
+    assert dut_if.read_rob_alloc_req()["alloc_valid"] == 1
+    assert dut_if.read_rob_alloc_req_2()["alloc_valid"] == 0
+    assert not dut_if.rat_alloc_valid_2
+    assert dut_if.read_int_rs_dispatch()["valid"] == 1
+    assert dut_if.read_fp_rs_dispatch_2()["valid"] == 0
+
+
+@cocotb.test()
+async def test_slot2_memory_routes_to_mem_rs(dut: Any) -> None:
+    """Slot-2 loads and stores should route to MEM_RS with LQ/SQ intent."""
+    dut_if = await _setup(dut)
+
+    dut_if.drive_rob_alloc_resp(alloc_ready=1, alloc_tag=8, full=0)
+    dut_if.drive_rob_alloc_resp_2(alloc_ready=1, alloc_tag=9, full=0)
+    dut_if.drive_instruction(
+        valid=True,
+        instruction_operation=ADD,
+        instruction=_make_instr(dest_reg=1, opcode=OPC_OP),
+    )
+    dut_if.drive_instruction_2(
+        valid=True,
+        rs1_addr=2,
+        instruction_operation=LW,
+        immediate_i_type=16,
+        instruction=_make_instr(dest_reg=5, opcode=OPC_LOAD, source_reg_1=2),
+    )
+    await dut_if.step()
+
+    load_req = dut_if.read_rob_alloc_req_2()
+    load_rs = dut_if.read_mem_rs_dispatch_2()
+    assert load_req["alloc_valid"] == 1
+    assert load_req["dest_valid"] == 1
+    assert load_req["dest_reg"] == 5
+    assert load_rs["valid"] == 1
+    assert load_rs["rs_type"] == RS_MEM
+    assert load_rs["mem_needs_lq"] == 1
+    assert load_rs["mem_needs_sq"] == 0
+    assert load_rs["use_imm"] == 1
+    assert load_rs["imm"] == 16
+
+    dut_if.drive_rob_alloc_resp(alloc_ready=1, alloc_tag=10, full=0)
+    dut_if.drive_rob_alloc_resp_2(alloc_ready=1, alloc_tag=11, full=0)
+    dut_if.drive_instruction(
+        valid=True,
+        instruction_operation=ADD,
+        instruction=_make_instr(dest_reg=3, opcode=OPC_OP),
+    )
+    dut_if.drive_instruction_2(
+        valid=True,
+        rs1_addr=4,
+        rs2_addr=5,
+        instruction_operation=SW,
+        immediate_s_type=32,
+        instruction=_make_instr(
+            opcode=OPC_STORE,
+            source_reg_1=4,
+            source_reg_2=5,
+        ),
+    )
+    await dut_if.step()
+
+    store_req = dut_if.read_rob_alloc_req_2()
+    store_rs = dut_if.read_mem_rs_dispatch_2()
+    assert store_req["alloc_valid"] == 1
+    assert store_req["is_store"] == 1
+    assert store_req["dest_valid"] == 0
+    assert store_rs["valid"] == 1
+    assert store_rs["rs_type"] == RS_MEM
+    assert store_rs["mem_needs_lq"] == 0
+    assert store_rs["mem_needs_sq"] == 1
+    assert store_rs["use_imm"] == 1
+    assert store_rs["imm"] == 32
+    assert not dut_if.rat_alloc_valid_2
 
 
 # =============================================================================

--- a/verif/cocotb_tests/tomasulo/load_queue/lq_interface.py
+++ b/verif/cocotb_tests/tomasulo/load_queue/lq_interface.py
@@ -240,9 +240,35 @@ class LQInterface:
             amo_op=amo_op,
         )
 
+    def drive_alloc_2(
+        self,
+        rob_tag: int,
+        is_fp: bool = False,
+        size: int = 2,
+        sign_ext: bool = False,
+        is_lr: bool = False,
+        is_amo: bool = False,
+        amo_op: int = 0,
+    ) -> None:
+        """Drive slot-2 allocation request."""
+        self.dut.i_alloc_2.value = pack_lq_alloc(
+            valid=True,
+            rob_tag=rob_tag,
+            is_fp=is_fp,
+            size=size,
+            sign_ext=sign_ext,
+            is_lr=is_lr,
+            is_amo=is_amo,
+            amo_op=amo_op,
+        )
+
     def clear_alloc(self) -> None:
         """Clear allocation request."""
         self.dut.i_alloc.value = 0
+
+    def clear_alloc_2(self) -> None:
+        """Clear slot-2 allocation request."""
+        self.dut.i_alloc_2.value = 0
 
     # =========================================================================
     # Address Update
@@ -387,6 +413,11 @@ class LQInterface:
     def full(self) -> bool:
         """Return whether the load queue is full."""
         return bool(self.dut.o_full.value)
+
+    @property
+    def full_for_2(self) -> bool:
+        """Return whether there is room for fewer than two new entries."""
+        return bool(self.dut.o_full_for_2.value)
 
     @property
     def empty(self) -> bool:

--- a/verif/cocotb_tests/tomasulo/load_queue/test_load_queue.py
+++ b/verif/cocotb_tests/tomasulo/load_queue/test_load_queue.py
@@ -234,6 +234,75 @@ async def test_alloc_single(dut: Any) -> None:
 
 
 # ============================================================================
+# Test 2b: Allocate slot 2 only
+# ============================================================================
+@cocotb.test()
+async def test_alloc_slot2_only(dut: Any) -> None:
+    """Slot-2-only load allocation takes the next free entry and can complete."""
+    dut_if, model = await setup(dut)
+
+    dut_if.drive_alloc_2(rob_tag=6, size=MEM_SIZE_WORD)
+    model.alloc(6, False, MEM_SIZE_WORD, False)
+    await dut_if.step()
+    dut_if.clear_alloc_2()
+
+    assert dut_if.count == 1, f"Expected count=1, got {dut_if.count}"
+    assert not dut_if.empty, "Should not be empty after slot-2-only alloc"
+
+    dut_if.drive_addr_update(rob_tag=6, address=0x1060)
+    model.addr_update(6, 0x1060)
+    await dut_if.step()
+    dut_if.clear_addr_update()
+
+    result = await complete_load_no_forward(dut_if, model, mem_data=0x1234_5678)
+
+    assert result.valid, "Slot-2-only load should complete"
+    assert result.tag == 6, f"Expected tag=6, got {result.tag}"
+    assert result.value == 0x1234_5678
+
+
+# ============================================================================
+# Test 2c: Allocate slot 1 + slot 2 in the same cycle
+# ============================================================================
+@cocotb.test()
+async def test_alloc_slot1_slot2_pair_completes_in_order(dut: Any) -> None:
+    """Two simultaneous load allocations preserve program-order completion."""
+    dut_if, model = await setup(dut)
+
+    dut_if.drive_alloc(rob_tag=10, size=MEM_SIZE_WORD)
+    dut_if.drive_alloc_2(rob_tag=11, size=MEM_SIZE_WORD)
+    model.alloc(10, False, MEM_SIZE_WORD, False)
+    model.alloc(11, False, MEM_SIZE_WORD, False)
+    await dut_if.step()
+    dut_if.clear_alloc()
+    dut_if.clear_alloc_2()
+
+    assert dut_if.count == 2, f"Expected two allocated entries, got {dut_if.count}"
+
+    dut_if.drive_addr_update(rob_tag=10, address=0x1100)
+    model.addr_update(10, 0x1100)
+    await dut_if.step()
+    dut_if.clear_addr_update()
+
+    dut_if.drive_addr_update(rob_tag=11, address=0x1104)
+    model.addr_update(11, 0x1104)
+    await dut_if.step()
+    dut_if.clear_addr_update()
+
+    first = await complete_load_no_forward(dut_if, model, mem_data=0xAAAA_0001)
+    assert (
+        first.valid and first.tag == 10
+    ), f"Expected first completion tag=10, got {first}"
+    assert first.value == 0xAAAA_0001
+
+    second = await complete_load_no_forward(dut_if, model, mem_data=0xBBBB_0002)
+    assert (
+        second.valid and second.tag == 11
+    ), f"Expected second completion tag=11, got {second}"
+    assert second.value == 0xBBBB_0002
+
+
+# ============================================================================
 # Test 3: Allocate to full
 # ============================================================================
 @cocotb.test()

--- a/verif/cocotb_tests/tomasulo/register_alias_table/rat_interface.py
+++ b/verif/cocotb_tests/tomasulo/register_alias_table/rat_interface.py
@@ -24,7 +24,15 @@ This interface handles packing/unpacking struct fields automatically.
 from typing import Any
 from cocotb.triggers import RisingEdge, FallingEdge
 
-from .rat_model import LookupResult, MASK32, MASK64, MASK_TAG, MASK_REG, RATModel
+from .rat_model import (
+    ALL_ROB_ENTRIES_VALID,
+    LookupResult,
+    MASK32,
+    MASK64,
+    MASK_TAG,
+    MASK_REG,
+    RATModel,
+)
 
 # =============================================================================
 # Struct Bit Field Definitions
@@ -57,11 +65,15 @@ class RATInterface:
         self._shadow_rat = RATModel()
         self._rob_tag_refcounts = [0] * (MASK_TAG + 1)
         self._rob_head_tag = 0
+        self._rob_entry_epoch_mask = 0
         self._pending_rename: tuple[int, int, int] | None = None
+        self._pending_rename_2: tuple[int, int, int] | None = None
         self._pending_commit: tuple[int, int, int, bool] | None = None
-        self._pending_checkpoint_save: tuple[int, int, int, int] | None = None
+        self._pending_commit_2: tuple[int, int, int, bool] | None = None
+        self._pending_checkpoint_save: tuple[int, int, int, int, bool] | None = None
         self._pending_checkpoint_restore: int | None = None
         self._pending_checkpoint_free: int | None = None
+        self._pending_checkpoint_bulk_free_mask = 0
         self._pending_flush_all = False
 
     # =========================================================================
@@ -112,11 +124,15 @@ class RATInterface:
         self._shadow_rat = RATModel()
         self._rob_tag_refcounts = [0] * (MASK_TAG + 1)
         self._rob_head_tag = 0
+        self._rob_entry_epoch_mask = 0
         self._pending_rename = None
+        self._pending_rename_2 = None
         self._pending_commit = None
+        self._pending_commit_2 = None
         self._pending_checkpoint_save = None
         self._pending_checkpoint_restore = None
         self._pending_checkpoint_free = None
+        self._pending_checkpoint_bulk_free_mask = 0
         self._pending_flush_all = False
 
         # Source lookup addresses - slot 1
@@ -210,7 +226,12 @@ class RATInterface:
     @property
     def rob_entry_epoch_mask(self) -> int:
         """Return the synthetic ROB epoch bitmask used by standalone tests."""
-        return 0
+        return self._rob_entry_epoch_mask
+
+    def set_rob_entry_epoch_mask(self, epoch_mask: int) -> None:
+        """Set the synthetic ROB epoch bitmask used by standalone tests."""
+        self._rob_entry_epoch_mask = epoch_mask & ALL_ROB_ENTRIES_VALID
+        self._drive_rob_entry_valid()
 
     @property
     def rob_head_tag(self) -> int:
@@ -228,10 +249,13 @@ class RATInterface:
         """Apply queued same-cycle effects to the synthetic ROB-valid vector."""
         if (
             self._pending_rename is None
+            and self._pending_rename_2 is None
             and self._pending_commit is None
+            and self._pending_commit_2 is None
             and self._pending_checkpoint_save is None
             and self._pending_checkpoint_restore is None
             and self._pending_checkpoint_free is None
+            and self._pending_checkpoint_bulk_free_mask == 0
             and not self._pending_flush_all
         ):
             return
@@ -247,15 +271,25 @@ class RATInterface:
                 rob_head_tag=self._rob_head_tag,
             )
         else:
+            if self._pending_checkpoint_bulk_free_mask:
+                self._shadow_rat.checkpoint_bulk_free(
+                    self._pending_checkpoint_bulk_free_mask
+                )
+
             if self._pending_checkpoint_free is not None:
                 self._shadow_rat.checkpoint_free(self._pending_checkpoint_free)
 
             if self._pending_checkpoint_save is not None:
-                checkpoint_id, branch_tag, ras_tos, ras_valid_count = (
+                checkpoint_id, branch_tag, ras_tos, ras_valid_count, for_slot2 = (
                     self._pending_checkpoint_save
                 )
+                overlay_rename = self._pending_rename if for_slot2 else None
                 self._shadow_rat.checkpoint_save(
-                    checkpoint_id, branch_tag, ras_tos, ras_valid_count
+                    checkpoint_id,
+                    branch_tag,
+                    ras_tos,
+                    ras_valid_count,
+                    overlay_rename,
                 )
 
             if self._pending_commit is not None:
@@ -281,18 +315,56 @@ class RATInterface:
                             if self._rob_tag_refcounts[commit_tag] > 0:
                                 self._rob_tag_refcounts[commit_tag] -= 1
 
+            if self._pending_commit_2 is not None:
+                commit_tag, commit_dest_rf, commit_dest_reg, commit_dest_valid = (
+                    self._pending_commit_2
+                )
+                if commit_dest_valid:
+                    if commit_dest_rf == 0:
+                        if commit_dest_reg != 0:
+                            entry = self._shadow_rat.int_rat[commit_dest_reg]
+                            if entry.valid and entry.tag == commit_tag:
+                                self._shadow_rat.commit(
+                                    commit_dest_rf, commit_dest_reg, commit_tag
+                                )
+                                if self._rob_tag_refcounts[commit_tag] > 0:
+                                    self._rob_tag_refcounts[commit_tag] -= 1
+                    else:
+                        entry = self._shadow_rat.fp_rat[commit_dest_reg]
+                        if entry.valid and entry.tag == commit_tag:
+                            self._shadow_rat.commit(
+                                commit_dest_rf, commit_dest_reg, commit_tag
+                            )
+                            if self._rob_tag_refcounts[commit_tag] > 0:
+                                self._rob_tag_refcounts[commit_tag] -= 1
+
             if self._pending_rename is not None:
                 dest_rf, dest_reg, rob_tag = self._pending_rename
+                rename_2_collides = (
+                    self._pending_rename_2 is not None
+                    and dest_rf == self._pending_rename_2[0]
+                    and dest_reg == self._pending_rename_2[1]
+                )
+                if not rename_2_collides:
+                    self._shadow_rat.rename(dest_rf, dest_reg, rob_tag)
+                if not (dest_rf == 0 and dest_reg == 0):
+                    self._rob_tag_refcounts[rob_tag] += 1
+
+            if self._pending_rename_2 is not None:
+                dest_rf, dest_reg, rob_tag = self._pending_rename_2
                 self._shadow_rat.rename(dest_rf, dest_reg, rob_tag)
                 if not (dest_rf == 0 and dest_reg == 0):
                     self._rob_tag_refcounts[rob_tag] += 1
 
         self._drive_rob_entry_valid()
         self._pending_rename = None
+        self._pending_rename_2 = None
         self._pending_commit = None
+        self._pending_commit_2 = None
         self._pending_checkpoint_save = None
         self._pending_checkpoint_restore = None
         self._pending_checkpoint_free = None
+        self._pending_checkpoint_bulk_free_mask = 0
         self._pending_flush_all = False
 
     # =========================================================================
@@ -324,6 +396,31 @@ class RATInterface:
         self.dut.i_fp_src3_addr.value = addr & MASK_REG
         self.dut.i_fp_regfile_data3.value = regfile_data & MASK64
 
+    def set_int_src1_2(self, addr: int, regfile_data: int) -> None:
+        """Set slot-2 INT source 1 lookup inputs."""
+        self.dut.i_int_src1_addr_2.value = addr & MASK_REG
+        self.dut.i_int_regfile_data1_2.value = regfile_data & MASK32
+
+    def set_int_src2_2(self, addr: int, regfile_data: int) -> None:
+        """Set slot-2 INT source 2 lookup inputs."""
+        self.dut.i_int_src2_addr_2.value = addr & MASK_REG
+        self.dut.i_int_regfile_data2_2.value = regfile_data & MASK32
+
+    def set_fp_src1_2(self, addr: int, regfile_data: int) -> None:
+        """Set slot-2 FP source 1 lookup inputs."""
+        self.dut.i_fp_src1_addr_2.value = addr & MASK_REG
+        self.dut.i_fp_regfile_data1_2.value = regfile_data & MASK64
+
+    def set_fp_src2_2(self, addr: int, regfile_data: int) -> None:
+        """Set slot-2 FP source 2 lookup inputs."""
+        self.dut.i_fp_src2_addr_2.value = addr & MASK_REG
+        self.dut.i_fp_regfile_data2_2.value = regfile_data & MASK64
+
+    def set_fp_src3_2(self, addr: int, regfile_data: int) -> None:
+        """Set slot-2 FP source 3 lookup inputs."""
+        self.dut.i_fp_src3_addr_2.value = addr & MASK_REG
+        self.dut.i_fp_regfile_data3_2.value = regfile_data & MASK64
+
     def read_int_src1(self) -> LookupResult:
         """Read INT source 1 lookup result."""
         return unpack_rat_lookup(int(self.dut.o_int_src1.value))
@@ -344,6 +441,26 @@ class RATInterface:
         """Read FP source 3 lookup result."""
         return unpack_rat_lookup(int(self.dut.o_fp_src3.value))
 
+    def read_int_src1_2(self) -> LookupResult:
+        """Read slot-2 INT source 1 lookup result."""
+        return unpack_rat_lookup(int(self.dut.o_int_src1_2.value))
+
+    def read_int_src2_2(self) -> LookupResult:
+        """Read slot-2 INT source 2 lookup result."""
+        return unpack_rat_lookup(int(self.dut.o_int_src2_2.value))
+
+    def read_fp_src1_2(self) -> LookupResult:
+        """Read slot-2 FP source 1 lookup result."""
+        return unpack_rat_lookup(int(self.dut.o_fp_src1_2.value))
+
+    def read_fp_src2_2(self) -> LookupResult:
+        """Read slot-2 FP source 2 lookup result."""
+        return unpack_rat_lookup(int(self.dut.o_fp_src2_2.value))
+
+    def read_fp_src3_2(self) -> LookupResult:
+        """Read slot-2 FP source 3 lookup result."""
+        return unpack_rat_lookup(int(self.dut.o_fp_src3_2.value))
+
     # =========================================================================
     # Rename Write Interface
     # =========================================================================
@@ -361,6 +478,23 @@ class RATInterface:
         self.dut.i_alloc_valid.value = 0
         self._apply_pending_cycle_updates()
 
+    def drive_rename_2(self, dest_rf: int, dest_reg: int, rob_tag: int) -> None:
+        """Drive slot-2 rename write signals."""
+        self.dut.i_alloc_valid_2.value = 1
+        self.dut.i_alloc_dest_rf_2.value = dest_rf & 1
+        self.dut.i_alloc_dest_reg_2.value = dest_reg & MASK_REG
+        self.dut.i_alloc_rob_tag_2.value = rob_tag & MASK_TAG
+        self._pending_rename_2 = (
+            dest_rf & 1,
+            dest_reg & MASK_REG,
+            rob_tag & MASK_TAG,
+        )
+
+    def clear_rename_2(self) -> None:
+        """Clear slot-2 rename write signals."""
+        self.dut.i_alloc_valid_2.value = 0
+        self._apply_pending_cycle_updates()
+
     async def rename(self, dest_rf: int, dest_reg: int, rob_tag: int) -> None:
         """Perform rename transaction: drive on falling, wait rising+falling, clear."""
         await FallingEdge(self.clock)
@@ -368,6 +502,14 @@ class RATInterface:
         await RisingEdge(self.clock)
         await FallingEdge(self.clock)
         self.clear_rename()
+
+    async def rename_2(self, dest_rf: int, dest_reg: int, rob_tag: int) -> None:
+        """Perform slot-2 rename transaction."""
+        await FallingEdge(self.clock)
+        self.drive_rename_2(dest_rf, dest_reg, rob_tag)
+        await RisingEdge(self.clock)
+        await FallingEdge(self.clock)
+        self.clear_rename_2()
 
     # =========================================================================
     # Commit Interface
@@ -398,6 +540,31 @@ class RATInterface:
         self.dut.i_commit_tag.value = 0
         self._apply_pending_cycle_updates()
 
+    def drive_commit_2(
+        self, tag: int, dest_rf: int, dest_reg: int, dest_valid: bool = True
+    ) -> None:
+        """Drive slot-2 commit signals."""
+        self.dut.i_commit_valid_2.value = 1
+        self.dut.i_commit_dest_valid_2.value = 1 if dest_valid else 0
+        self.dut.i_commit_dest_rf_2.value = dest_rf & 1
+        self.dut.i_commit_dest_reg_2.value = dest_reg & MASK_REG
+        self.dut.i_commit_tag_2.value = tag & MASK_TAG
+        self._pending_commit_2 = (
+            tag & MASK_TAG,
+            dest_rf & 1,
+            dest_reg & MASK_REG,
+            dest_valid,
+        )
+
+    def clear_commit_2(self) -> None:
+        """Clear slot-2 commit signals."""
+        self.dut.i_commit_valid_2.value = 0
+        self.dut.i_commit_dest_valid_2.value = 0
+        self.dut.i_commit_dest_rf_2.value = 0
+        self.dut.i_commit_dest_reg_2.value = 0
+        self.dut.i_commit_tag_2.value = 0
+        self._apply_pending_cycle_updates()
+
     async def commit(
         self, tag: int, dest_rf: int, dest_reg: int, dest_valid: bool = True
     ) -> None:
@@ -407,6 +574,16 @@ class RATInterface:
         await RisingEdge(self.clock)
         await FallingEdge(self.clock)
         self.clear_commit()
+
+    async def commit_2(
+        self, tag: int, dest_rf: int, dest_reg: int, dest_valid: bool = True
+    ) -> None:
+        """Perform slot-2 commit transaction."""
+        await FallingEdge(self.clock)
+        self.drive_commit_2(tag, dest_rf, dest_reg, dest_valid)
+        await RisingEdge(self.clock)
+        await FallingEdge(self.clock)
+        self.clear_commit_2()
 
     # =========================================================================
     # Checkpoint Save Interface
@@ -418,6 +595,7 @@ class RATInterface:
         branch_tag: int,
         ras_tos: int = 0,
         ras_valid_count: int = 0,
+        for_slot2: bool = False,
     ) -> None:
         """Drive checkpoint save signals."""
         self.dut.i_checkpoint_save.value = 1
@@ -425,16 +603,19 @@ class RATInterface:
         self.dut.i_checkpoint_branch_tag.value = branch_tag & MASK_TAG
         self.dut.i_ras_tos.value = ras_tos & 0x7
         self.dut.i_ras_valid_count.value = ras_valid_count & 0xF
+        self.dut.i_checkpoint_save_for_slot2.value = 1 if for_slot2 else 0
         self._pending_checkpoint_save = (
             checkpoint_id & 0x7,
             branch_tag & MASK_TAG,
             ras_tos & 0x7,
             ras_valid_count & 0xF,
+            for_slot2,
         )
 
     def clear_checkpoint_save(self) -> None:
         """Clear checkpoint save signals."""
         self.dut.i_checkpoint_save.value = 0
+        self.dut.i_checkpoint_save_for_slot2.value = 0
         self._apply_pending_cycle_updates()
 
     async def checkpoint_save(
@@ -443,10 +624,13 @@ class RATInterface:
         branch_tag: int,
         ras_tos: int = 0,
         ras_valid_count: int = 0,
+        for_slot2: bool = False,
     ) -> None:
         """Perform checkpoint save transaction."""
         await FallingEdge(self.clock)
-        self.drive_checkpoint_save(checkpoint_id, branch_tag, ras_tos, ras_valid_count)
+        self.drive_checkpoint_save(
+            checkpoint_id, branch_tag, ras_tos, ras_valid_count, for_slot2
+        )
         await RisingEdge(self.clock)
         await FallingEdge(self.clock)
         self.clear_checkpoint_save()
@@ -496,6 +680,16 @@ class RATInterface:
         self.dut.i_checkpoint_free.value = 0
         self._apply_pending_cycle_updates()
 
+    def drive_checkpoint_bulk_free(self, free_mask: int) -> None:
+        """Drive checkpoint bulk free mask."""
+        self.dut.i_checkpoint_flush_free_mask.value = free_mask & 0xFF
+        self._pending_checkpoint_bulk_free_mask = free_mask & 0xFF
+
+    def clear_checkpoint_bulk_free(self) -> None:
+        """Clear checkpoint bulk free mask."""
+        self.dut.i_checkpoint_flush_free_mask.value = 0
+        self._apply_pending_cycle_updates()
+
     async def checkpoint_free(self, checkpoint_id: int) -> None:
         """Perform checkpoint free transaction."""
         await FallingEdge(self.clock)
@@ -503,6 +697,14 @@ class RATInterface:
         await RisingEdge(self.clock)
         await FallingEdge(self.clock)
         self.clear_checkpoint_free()
+
+    async def checkpoint_bulk_free(self, free_mask: int) -> None:
+        """Perform checkpoint bulk free transaction."""
+        await FallingEdge(self.clock)
+        self.drive_checkpoint_bulk_free(free_mask)
+        await RisingEdge(self.clock)
+        await FallingEdge(self.clock)
+        self.clear_checkpoint_bulk_free()
 
     # =========================================================================
     # Flush Interface

--- a/verif/cocotb_tests/tomasulo/register_alias_table/rat_model.py
+++ b/verif/cocotb_tests/tomasulo/register_alias_table/rat_model.py
@@ -207,6 +207,7 @@ class RATModel:
         branch_tag: int,
         ras_tos: int,
         ras_valid_count: int,
+        overlay_rename: tuple[int, int, int] | None = None,
     ) -> None:
         """Save current RAT state into a checkpoint slot.
 
@@ -215,15 +216,29 @@ class RATModel:
             branch_tag: ROB tag of the branch instruction.
             ras_tos: RAS top-of-stack pointer.
             ras_valid_count: RAS valid entry count.
+            overlay_rename: Optional same-cycle slot-1 rename to include in
+                the saved image for a slot-2 branch checkpoint.
         """
         slot = self.checkpoints[checkpoint_id]
         slot.valid = True
         slot.branch_tag = branch_tag & MASK_TAG
         slot.ras_tos = ras_tos
         slot.ras_valid_count = ras_valid_count
-        # Deep copy current RAT state
-        slot.int_rat = [RATEntry(valid=e.valid, tag=e.tag) for e in self.int_rat]
-        slot.fp_rat = [RATEntry(valid=e.valid, tag=e.tag) for e in self.fp_rat]
+        int_snapshot = [RATEntry(valid=e.valid, tag=e.tag) for e in self.int_rat]
+        fp_snapshot = [RATEntry(valid=e.valid, tag=e.tag) for e in self.fp_rat]
+
+        if overlay_rename is not None:
+            dest_rf, dest_reg, rob_tag = overlay_rename
+            if dest_rf == 0:
+                if dest_reg != 0:
+                    int_snapshot[dest_reg] = RATEntry(
+                        valid=True, tag=rob_tag & MASK_TAG
+                    )
+            else:
+                fp_snapshot[dest_reg] = RATEntry(valid=True, tag=rob_tag & MASK_TAG)
+
+        slot.int_rat = int_snapshot
+        slot.fp_rat = fp_snapshot
 
     def _restored_tag_still_live(
         self,
@@ -306,6 +321,16 @@ class RATModel:
             checkpoint_id: Slot index.
         """
         self.checkpoints[checkpoint_id].valid = False
+
+    def checkpoint_bulk_free(self, free_mask: int) -> None:
+        """Free all checkpoint slots selected by a bit mask.
+
+        Args:
+            free_mask: One bit per checkpoint slot. A set bit clears that slot.
+        """
+        for checkpoint_id in range(NUM_CHECKPOINTS):
+            if (free_mask >> checkpoint_id) & 1:
+                self.checkpoint_free(checkpoint_id)
 
     def checkpoint_available(self) -> tuple[bool, int]:
         """Check if a free checkpoint slot is available.

--- a/verif/cocotb_tests/tomasulo/register_alias_table/test_register_alias_table.py
+++ b/verif/cocotb_tests/tomasulo/register_alias_table/test_register_alias_table.py
@@ -1243,6 +1243,314 @@ async def test_regfile_value_passthrough(dut: Any) -> None:
 
 
 # =============================================================================
+# Slot-2 / 2-Wide Tests
+# =============================================================================
+
+
+@cocotb.test()
+async def test_slot2_source_lookups(dut: Any) -> None:
+    """Test slot-2 INT/FP lookup ports."""
+    cocotb.log.info("=== Test: Slot-2 Source Lookups ===")
+
+    dut_if, model = await setup_test(dut)
+
+    await dut_if.rename(dest_rf=0, dest_reg=5, rob_tag=3)
+    model.rename(0, 5, 3)
+    await dut_if.rename(dest_rf=1, dest_reg=10, rob_tag=7)
+    model.rename(1, 10, 7)
+
+    dut_if.set_int_src1_2(5, 0x1111_2222)
+    dut_if.set_int_src2_2(0, 0x3333_4444)
+    dut_if.set_fp_src1_2(10, 0xAAAA_BBBB_CCCC_DDDD)
+    dut_if.set_fp_src2_2(11, 0x1111_2222_3333_4444)
+    dut_if.set_fp_src3_2(10, 0x5555_6666_7777_8888)
+    await RisingEdge(dut_if.clock)
+
+    check_lookup(
+        dut_if.read_int_src1_2(),
+        model.lookup_int(5, 0x1111_2222),
+        "slot-2 INT src1 x5",
+    )
+    check_lookup(
+        dut_if.read_int_src2_2(),
+        model.lookup_int(0, 0x3333_4444),
+        "slot-2 INT src2 x0",
+    )
+    check_lookup(
+        dut_if.read_fp_src1_2(),
+        model.lookup_fp(10, 0xAAAA_BBBB_CCCC_DDDD),
+        "slot-2 FP src1 f10",
+    )
+    check_lookup(
+        dut_if.read_fp_src2_2(),
+        model.lookup_fp(11, 0x1111_2222_3333_4444),
+        "slot-2 FP src2 f11",
+    )
+    check_lookup(
+        dut_if.read_fp_src3_2(),
+        model.lookup_fp(10, 0x5555_6666_7777_8888),
+        "slot-2 FP src3 f10",
+    )
+
+    cocotb.log.info("=== Test Passed ===")
+
+
+@cocotb.test()
+async def test_slot2_rename_and_lookup(dut: Any) -> None:
+    """Test slot-2-only rename writes INT and FP RAT entries."""
+    cocotb.log.info("=== Test: Slot-2 Rename and Lookup ===")
+
+    dut_if, model = await setup_test(dut)
+
+    await dut_if.rename_2(dest_rf=0, dest_reg=6, rob_tag=9)
+    model.rename(0, 6, 9)
+
+    dut_if.set_int_src1(6, 0x1234)
+    await RisingEdge(dut_if.clock)
+    result = dut_if.read_int_src1()
+    expected = model.lookup_int(6, 0x1234)
+    check_lookup(result, expected, "INT x6 after slot-2 rename")
+    assert result.renamed and result.tag == 9, "x6 should carry slot-2 tag 9"
+
+    await dut_if.rename_2(dest_rf=1, dest_reg=8, rob_tag=10)
+    model.rename(1, 8, 10)
+
+    dut_if.set_fp_src1(8, 0x4000_0000_0000_0000)
+    await RisingEdge(dut_if.clock)
+    result = dut_if.read_fp_src1()
+    expected = model.lookup_fp(8, 0x4000_0000_0000_0000)
+    check_lookup(result, expected, "FP f8 after slot-2 rename")
+    assert result.renamed and result.tag == 10, "f8 should carry slot-2 tag 10"
+
+    cocotb.log.info("=== Test Passed ===")
+
+
+@cocotb.test()
+async def test_dual_rename_slot2_wins_same_register(dut: Any) -> None:
+    """Same-cycle slot1/slot2 rename collision leaves slot 2 as newest."""
+    cocotb.log.info("=== Test: Dual Rename Slot 2 Wins Same Register ===")
+
+    dut_if, model = await setup_test(dut)
+
+    await FallingEdge(dut_if.clock)
+    dut_if.drive_rename(dest_rf=0, dest_reg=5, rob_tag=3)
+    dut_if.drive_rename_2(dest_rf=0, dest_reg=5, rob_tag=4)
+    model.rename(0, 5, 4)
+    await RisingEdge(dut_if.clock)
+    await FallingEdge(dut_if.clock)
+    dut_if.clear_rename()
+    dut_if.clear_rename_2()
+
+    dut_if.set_int_src1(5, 0)
+    await RisingEdge(dut_if.clock)
+    result = dut_if.read_int_src1()
+    expected = model.lookup_int(5, 0)
+    check_lookup(result, expected, "INT x5 after dual rename collision")
+    assert result.renamed and result.tag == 4, "slot-2 rename should win"
+
+    await FallingEdge(dut_if.clock)
+    dut_if.drive_rename(dest_rf=0, dest_reg=6, rob_tag=5)
+    dut_if.drive_rename_2(dest_rf=1, dest_reg=6, rob_tag=6)
+    model.rename(0, 6, 5)
+    model.rename(1, 6, 6)
+    await RisingEdge(dut_if.clock)
+    await FallingEdge(dut_if.clock)
+    dut_if.clear_rename()
+    dut_if.clear_rename_2()
+
+    dut_if.set_int_src1(6, 0)
+    dut_if.set_fp_src1(6, 0)
+    await RisingEdge(dut_if.clock)
+    int_result = dut_if.read_int_src1()
+    fp_result = dut_if.read_fp_src1()
+    check_lookup(int_result, model.lookup_int(6, 0), "INT x6 after dual rename")
+    check_lookup(fp_result, model.lookup_fp(6, 0), "FP f6 after dual rename")
+    assert int_result.renamed and int_result.tag == 5, "x6 should keep slot-1 tag"
+    assert fp_result.renamed and fp_result.tag == 6, "f6 should get slot-2 tag"
+
+    cocotb.log.info("=== Test Passed ===")
+
+
+@cocotb.test()
+async def test_slot2_commit_clears_entry(dut: Any) -> None:
+    """Test widen-commit slot 2 clears a matching RAT entry."""
+    cocotb.log.info("=== Test: Slot-2 Commit Clears Entry ===")
+
+    dut_if, model = await setup_test(dut)
+
+    await dut_if.rename_2(dest_rf=0, dest_reg=7, rob_tag=11)
+    model.rename(0, 7, 11)
+
+    await dut_if.commit_2(tag=11, dest_rf=0, dest_reg=7)
+    model.commit(0, 7, 11)
+
+    dut_if.set_int_src1(7, 0xABCD)
+    await RisingEdge(dut_if.clock)
+    result = dut_if.read_int_src1()
+    expected = model.lookup_int(7, 0xABCD)
+    check_lookup(result, expected, "INT x7 after slot-2 commit")
+    assert not result.renamed, "x7 should clear on matching slot-2 commit"
+
+    cocotb.log.info("=== Test Passed ===")
+
+
+@cocotb.test()
+async def test_dual_commit_same_cycle(dut: Any) -> None:
+    """Slot 1 and slot 2 commits can clear independent RAT entries."""
+    cocotb.log.info("=== Test: Dual Commit Same Cycle ===")
+
+    dut_if, model = await setup_test(dut)
+
+    await dut_if.rename(dest_rf=0, dest_reg=5, rob_tag=3)
+    model.rename(0, 5, 3)
+    await dut_if.rename(dest_rf=1, dest_reg=10, rob_tag=12)
+    model.rename(1, 10, 12)
+
+    await FallingEdge(dut_if.clock)
+    dut_if.drive_commit(tag=3, dest_rf=0, dest_reg=5)
+    dut_if.drive_commit_2(tag=12, dest_rf=1, dest_reg=10)
+    model.commit(0, 5, 3)
+    model.commit(1, 10, 12)
+    await RisingEdge(dut_if.clock)
+    await FallingEdge(dut_if.clock)
+    dut_if.clear_commit()
+    dut_if.clear_commit_2()
+
+    dut_if.set_int_src1(5, 0x55)
+    dut_if.set_fp_src1(10, 0xAAAA)
+    await RisingEdge(dut_if.clock)
+    check_lookup(
+        dut_if.read_int_src1(),
+        model.lookup_int(5, 0x55),
+        "INT x5 after dual commit",
+    )
+    check_lookup(
+        dut_if.read_fp_src1(),
+        model.lookup_fp(10, 0xAAAA),
+        "FP f10 after dual commit",
+    )
+    assert not dut_if.read_int_src1().renamed, "x5 should clear"
+    assert not dut_if.read_fp_src1().renamed, "f10 should clear"
+
+    cocotb.log.info("=== Test Passed ===")
+
+
+@cocotb.test()
+async def test_rename_over_slot2_commit_same_cycle(dut: Any) -> None:
+    """A same-cycle rename wins over a slot-2 commit clear."""
+    cocotb.log.info("=== Test: Rename Over Slot-2 Commit Same Cycle ===")
+
+    dut_if, model = await setup_test(dut)
+
+    await dut_if.rename(dest_rf=0, dest_reg=5, rob_tag=3)
+    model.rename(0, 5, 3)
+
+    await FallingEdge(dut_if.clock)
+    dut_if.drive_commit_2(tag=3, dest_rf=0, dest_reg=5)
+    dut_if.drive_rename(dest_rf=0, dest_reg=5, rob_tag=10)
+    model.commit(0, 5, 3)
+    model.rename(0, 5, 10)
+    await RisingEdge(dut_if.clock)
+    await FallingEdge(dut_if.clock)
+    dut_if.clear_commit_2()
+    dut_if.clear_rename()
+
+    dut_if.set_int_src1(5, 0)
+    await RisingEdge(dut_if.clock)
+    result = dut_if.read_int_src1()
+    expected = model.lookup_int(5, 0)
+    check_lookup(result, expected, "INT x5 after rename over slot-2 commit")
+    assert result.renamed and result.tag == 10, "rename should win over commit"
+
+    cocotb.log.info("=== Test Passed ===")
+
+
+@cocotb.test()
+async def test_checkpoint_save_for_slot2_overlays_slot1_rename(dut: Any) -> None:
+    """Slot-2 branch checkpoint includes slot 1's rename but not slot 2's."""
+    cocotb.log.info("=== Test: Checkpoint Save for Slot-2 Overlay ===")
+
+    dut_if, model = await setup_test(dut)
+
+    await FallingEdge(dut_if.clock)
+    dut_if.drive_rename(dest_rf=0, dest_reg=5, rob_tag=3)
+    dut_if.drive_rename_2(dest_rf=0, dest_reg=6, rob_tag=4)
+    dut_if.drive_checkpoint_save(
+        checkpoint_id=0,
+        branch_tag=4,
+        ras_tos=1,
+        ras_valid_count=2,
+        for_slot2=True,
+    )
+    model.checkpoint_save(0, 4, 1, 2, overlay_rename=(0, 5, 3))
+    model.rename(0, 5, 3)
+    model.rename(0, 6, 4)
+    await RisingEdge(dut_if.clock)
+    await FallingEdge(dut_if.clock)
+    dut_if.clear_checkpoint_save()
+    dut_if.clear_rename()
+    dut_if.clear_rename_2()
+
+    await dut_if.rename(dest_rf=0, dest_reg=5, rob_tag=10)
+    model.rename(0, 5, 10)
+    await dut_if.rename(dest_rf=0, dest_reg=7, rob_tag=11)
+    model.rename(0, 7, 11)
+
+    dut_if.set_rob_entry_epoch_mask(1 << 3)
+    await FallingEdge(dut_if.clock)
+    dut_if.drive_checkpoint_restore(0)
+    await RisingEdge(dut_if.clock)
+    await FallingEdge(dut_if.clock)
+    dut_if.clear_checkpoint_restore()
+    model.checkpoint_restore(0)
+
+    dut_if.set_int_src1(5, 0)
+    await RisingEdge(dut_if.clock)
+    result = dut_if.read_int_src1()
+    expected = model.lookup_int(5, 0)
+    check_lookup(result, expected, "slot-1 rename restored from slot-2 checkpoint")
+    assert result.renamed and result.tag == 3, "x5 should restore slot-1 rename"
+
+    for reg in (6, 7):
+        dut_if.set_int_src1(reg, 0)
+        await RisingEdge(dut_if.clock)
+        result = dut_if.read_int_src1()
+        expected = model.lookup_int(reg, 0)
+        check_lookup(result, expected, f"INT x{reg} after slot-2 checkpoint restore")
+        assert not result.renamed, f"x{reg} should not survive slot-2 restore"
+
+    cocotb.log.info("=== Test Passed ===")
+
+
+@cocotb.test()
+async def test_checkpoint_bulk_free_mask(dut: Any) -> None:
+    """Bulk checkpoint free mask clears multiple slots in one cycle."""
+    cocotb.log.info("=== Test: Checkpoint Bulk Free Mask ===")
+
+    dut_if, model = await setup_test(dut)
+
+    for checkpoint_id in range(4):
+        await dut_if.checkpoint_save(checkpoint_id, branch_tag=checkpoint_id + 10)
+        model.checkpoint_save(checkpoint_id, checkpoint_id + 10, 0, 0)
+
+    assert dut_if.checkpoint_available, "Slots 4-7 should still be free"
+    assert dut_if.checkpoint_alloc_id == 4, "Next free slot should be 4"
+
+    free_mask = (1 << 1) | (1 << 3)
+    await dut_if.checkpoint_bulk_free(free_mask)
+    model.checkpoint_bulk_free(free_mask)
+
+    assert dut_if.checkpoint_available, "Bulk free should make slots available"
+    assert dut_if.checkpoint_alloc_id == 1, "Lowest bulk-freed slot should be next"
+
+    await dut_if.checkpoint_save(1, branch_tag=20)
+    model.checkpoint_save(1, 20, 0, 0)
+    assert dut_if.checkpoint_alloc_id == 3, "Slot 3 should remain bulk-freed"
+
+    cocotb.log.info("=== Test Passed ===")
+
+
+# =============================================================================
 # Constrained Random Tests
 # =============================================================================
 

--- a/verif/cocotb_tests/tomasulo/reservation_station/rs_interface.py
+++ b/verif/cocotb_tests/tomasulo/reservation_station/rs_interface.py
@@ -363,6 +363,21 @@ class RSInterface:
         else:
             self.dut.i_dispatch.value = 0
 
+    def drive_dispatch_2(self, intent_1: bool = False, **kwargs: Any) -> None:
+        """Drive slot-2 dispatch signals."""
+        kwargs["valid"] = True
+        self.dut.i_dispatch_2.value = pack_rs_dispatch(**kwargs)
+        self.set_intent_1(intent_1)
+
+    def clear_dispatch_2(self) -> None:
+        """Clear slot-2 dispatch and slot-1 intent."""
+        self.dut.i_dispatch_2.value = 0
+        self.set_intent_1(False)
+
+    def set_intent_1(self, active: bool = True) -> None:
+        """Drive fast slot-1 intent used by slot-2 allocation selection."""
+        self.dut.i_intent_1.value = 1 if active else 0
+
     def _drive_dispatch_flat(self, **kwargs: Any) -> None:
         """Drive individual dispatch ports from a flattened wrapper."""
         d = self.dut
@@ -521,6 +536,11 @@ class RSInterface:
     def full(self) -> bool:
         """Return whether RS is full."""
         return bool(self.dut.o_full.value)
+
+    @property
+    def full_for_2(self) -> bool:
+        """Return whether there is not enough room for a 2-wide dispatch."""
+        return bool(self.dut.o_full_for_2.value)
 
     @property
     def empty(self) -> bool:

--- a/verif/cocotb_tests/tomasulo/reservation_station/rs_model.py
+++ b/verif/cocotb_tests/tomasulo/reservation_station/rs_model.py
@@ -82,6 +82,10 @@ class RSModel:
         """Return whether all entries are valid."""
         return all(e.valid for e in self.entries)
 
+    def is_full_for_2(self) -> bool:
+        """Return whether there is not enough room for a 2-wide dispatch."""
+        return self.count() >= self.depth - 1
+
     def is_empty(self) -> bool:
         """Return whether no entries are valid."""
         return not any(e.valid for e in self.entries)

--- a/verif/cocotb_tests/tomasulo/reservation_station/test_reservation_station.py
+++ b/verif/cocotb_tests/tomasulo/reservation_station/test_reservation_station.py
@@ -323,6 +323,279 @@ async def test_dispatch_blocked_when_full(dut: Any) -> None:
     cocotb.log.info("=== Test Passed ===")
 
 
+@cocotb.test()
+async def test_dispatch_slot2_only_and_issue(dut: Any) -> None:
+    """Slot-2-only dispatch uses the first free entry and issues normally."""
+    cocotb.log.info("=== Test: Dispatch Slot 2 Only and Issue ===")
+    dut_if, model = await setup_test(dut)
+
+    dispatch: dict[str, Any] = {
+        "rob_tag": 8,
+        "op": OP_OR,
+        "src1_ready": True,
+        "src1_value": 0x1111_2222,
+        "src2_ready": True,
+        "src2_value": 0x3333_4444,
+        "src3_ready": True,
+        "src3_value": 0x5555_6666,
+        "imm": 0x1234_5678,
+        "rm": 2,
+        "branch_target": 0x8000_1000,
+        "predicted_taken": True,
+        "predicted_target": 0x8000_2000,
+        "is_fp_mem": True,
+        "mem_size": 2,
+        "mem_signed": True,
+        "csr_addr": 0x305,
+        "csr_imm": 0x7,
+    }
+
+    dut_if.drive_dispatch_2(**dispatch)
+    model.dispatch(**dispatch)
+    await dut_if.step()
+    dut_if.clear_dispatch_2()
+
+    empty_after_dispatch = dut_if.empty
+    assert not empty_after_dispatch, "Should not be empty after slot-2-only dispatch"
+    assert dut_if.count == 1, f"Count should be 1, got {dut_if.count}"
+
+    dut_if.set_fu_ready(True)
+    await dut_if.step()
+    issue = dut_if.read_issue()
+    model_issue = model.try_issue(fu_ready=True)
+    check_issue(issue, model_issue, "slot-2-only issue")
+    assert issue["rob_tag"] == 8, "Slot-2-only entry should issue"
+
+    await dut_if.step()
+    dut_if.set_fu_ready(False)
+    empty_after_issue = dut_if.empty
+    assert empty_after_issue, "Should be empty after issuing slot-2-only entry"
+
+    cocotb.log.info("=== Test Passed ===")
+
+
+@cocotb.test()
+async def test_dispatch_slot1_slot2_same_cycle_issue_order(dut: Any) -> None:
+    """Slot 1 and slot 2 can dispatch together and issue from distinct entries."""
+    cocotb.log.info("=== Test: Dispatch Slot 1 + Slot 2 Same Cycle ===")
+    dut_if, model = await setup_test(dut)
+
+    slot1: dict[str, Any] = {
+        "rob_tag": 10,
+        "op": OP_ADD,
+        "src1_ready": True,
+        "src1_value": 0x1000,
+        "src2_ready": True,
+        "src2_value": 0x2000,
+        "src3_ready": True,
+        "src3_value": 0x3000,
+        "imm": 0x10,
+    }
+    slot2: dict[str, Any] = {
+        "rob_tag": 11,
+        "op": OP_SUB,
+        "src1_ready": True,
+        "src1_value": 0x4000,
+        "src2_ready": True,
+        "src2_value": 0x5000,
+        "src3_ready": True,
+        "src3_value": 0x6000,
+        "imm": 0x20,
+    }
+
+    dut_if.drive_dispatch(**slot1)
+    dut_if.drive_dispatch_2(intent_1=True, **slot2)
+    model.dispatch(**slot1)
+    model.dispatch(**slot2)
+    await dut_if.step()
+    dut_if.clear_dispatch()
+    dut_if.clear_dispatch_2()
+
+    assert dut_if.count == 2, f"Count should be 2, got {dut_if.count}"
+
+    dut_if.set_fu_ready(True)
+    await dut_if.step()
+
+    for expected_tag in (10, 11):
+        issue = dut_if.read_issue()
+        model_issue = model.try_issue(fu_ready=True)
+        check_issue(issue, model_issue, f"dual dispatch issue tag={expected_tag}")
+        assert (
+            issue["rob_tag"] == expected_tag
+        ), f"Expected tag {expected_tag}, got {issue['rob_tag']}"
+        await dut_if.step()
+
+    assert dut_if.empty, "Should be empty after issuing both dual-dispatch entries"
+
+    cocotb.log.info("=== Test Passed ===")
+
+
+@cocotb.test()
+async def test_dispatch_slot2_cdb_bypass_at_dispatch(dut: Any) -> None:
+    """Slot-2 dispatch captures a same-cycle CDB source bypass."""
+    cocotb.log.info("=== Test: Slot 2 CDB Bypass at Dispatch ===")
+    dut_if, model = await setup_test(dut)
+
+    dut_if.drive_dispatch_2(
+        rob_tag=12,
+        op=OP_AND,
+        src1_ready=False,
+        src1_tag=6,
+        src2_ready=True,
+        src2_value=0x2222,
+        src3_ready=True,
+    )
+    dut_if.drive_cdb(tag=6, value=0xCAFE)
+    model.dispatch(
+        rob_tag=12,
+        op=OP_AND,
+        src1_ready=False,
+        src1_tag=6,
+        src2_ready=True,
+        src2_value=0x2222,
+        src3_ready=True,
+        cdb_valid=True,
+        cdb_tag=6,
+        cdb_value=0xCAFE,
+    )
+    await dut_if.step()
+    dut_if.clear_dispatch_2()
+    dut_if.clear_cdb()
+
+    dut_if.set_fu_ready(True)
+    await dut_if.step()
+    issue = dut_if.read_issue()
+    model_issue = model.try_issue(fu_ready=True)
+    check_issue(issue, model_issue, "slot-2 CDB bypass at dispatch")
+    assert issue["rob_tag"] == 12
+    assert issue["src1_value"] == 0xCAFE, "src1 should capture CDB value"
+
+    cocotb.log.info("=== Test Passed ===")
+
+
+@cocotb.test()
+async def test_full_for_2_blocks_slot2_of_dual_dispatch(dut: Any) -> None:
+    """Near-full RS accepts slot 1 but blocks slot 2 of a dual dispatch."""
+    cocotb.log.info("=== Test: Full-for-2 Blocks Slot 2 of Dual Dispatch ===")
+    dut_if, model = await setup_test(dut)
+
+    for i in range(RS_DEPTH - 1):
+        dispatch: dict[str, Any] = {
+            "rob_tag": i,
+            "op": OP_ADD,
+            "src1_ready": False,
+            "src1_tag": (i + 10) & MASK_TAG,
+            "src2_ready": False,
+            "src2_tag": (i + 20) & MASK_TAG,
+            "src3_ready": True,
+        }
+        dut_if.drive_dispatch(**dispatch)
+        model.dispatch(**dispatch)
+        await dut_if.step()
+        dut_if.clear_dispatch()
+
+    assert dut_if.count == RS_DEPTH - 1, f"Count should be {RS_DEPTH - 1}"
+    full_before_dual = dut_if.full
+    assert not full_before_dual, "Should not be full with one free entry"
+    assert dut_if.full_for_2, "Should be full_for_2 with one free entry"
+    assert model.is_full_for_2(), "Model should also be full_for_2"
+
+    slot1: dict[str, Any] = {
+        "rob_tag": 20,
+        "op": OP_OR,
+        "src1_ready": True,
+        "src1_value": 0xAAAA,
+        "src2_ready": True,
+        "src2_value": 0xBBBB,
+        "src3_ready": True,
+    }
+    slot2: dict[str, Any] = {
+        "rob_tag": 21,
+        "op": OP_SUB,
+        "src1_ready": True,
+        "src1_value": 0xCCCC,
+        "src2_ready": True,
+        "src2_value": 0xDDDD,
+        "src3_ready": True,
+    }
+
+    dut_if.drive_dispatch(**slot1)
+    dut_if.drive_dispatch_2(intent_1=True, **slot2)
+    model.dispatch(**slot1)
+    await dut_if.step()
+    dut_if.clear_dispatch()
+    dut_if.clear_dispatch_2()
+
+    assert (
+        dut_if.count == RS_DEPTH
+    ), f"Only slot 1 should be accepted, got {dut_if.count}"
+    full_after_slot1 = dut_if.full
+    assert full_after_slot1, "Should be full after accepting slot 1"
+
+    dut_if.set_fu_ready(True)
+    await dut_if.step()
+    issue = dut_if.read_issue()
+    model_issue = model.try_issue(fu_ready=True)
+    check_issue(issue, model_issue, "near-full accepted slot 1")
+    assert issue["rob_tag"] == 20, "Slot 2 should have been blocked"
+
+    cocotb.log.info("=== Test Passed ===")
+
+
+@cocotb.test()
+async def test_partial_flush_after_dual_dispatch(dut: Any) -> None:
+    """Partial flush removes a younger slot-2 entry from a dual dispatch."""
+    cocotb.log.info("=== Test: Partial Flush After Dual Dispatch ===")
+    dut_if, model = await setup_test(dut)
+
+    slot1: dict[str, Any] = {
+        "rob_tag": 1,
+        "op": OP_ADD,
+        "src1_ready": True,
+        "src1_value": 0x1111,
+        "src2_ready": True,
+        "src2_value": 0x2222,
+        "src3_ready": True,
+    }
+    slot2: dict[str, Any] = {
+        "rob_tag": 5,
+        "op": OP_SUB,
+        "src1_ready": True,
+        "src1_value": 0x3333,
+        "src2_ready": True,
+        "src2_value": 0x4444,
+        "src3_ready": True,
+    }
+
+    dut_if.drive_dispatch(**slot1)
+    dut_if.drive_dispatch_2(intent_1=True, **slot2)
+    model.dispatch(**slot1)
+    model.dispatch(**slot2)
+    await dut_if.step()
+    dut_if.clear_dispatch()
+    dut_if.clear_dispatch_2()
+
+    assert dut_if.count == 2, f"Count should be 2, got {dut_if.count}"
+
+    dut_if.drive_partial_flush(flush_tag=1, head_tag=0)
+    model.partial_flush(flush_tag=1, head_tag=0)
+    await dut_if.step()
+    dut_if.clear_partial_flush()
+
+    assert (
+        dut_if.count == 1
+    ), f"Only the older slot-1 entry should remain, got {dut_if.count}"
+
+    dut_if.set_fu_ready(True)
+    await dut_if.step()
+    issue = dut_if.read_issue()
+    model_issue = model.try_issue(fu_ready=True)
+    check_issue(issue, model_issue, "dual dispatch survivor")
+    assert issue["rob_tag"] == 1, "Older slot-1 entry should survive flush"
+
+    cocotb.log.info("=== Test Passed ===")
+
+
 # =============================================================================
 # CDB Wakeup Tests
 # =============================================================================

--- a/verif/cocotb_tests/tomasulo/store_queue/sq_interface.py
+++ b/verif/cocotb_tests/tomasulo/store_queue/sq_interface.py
@@ -171,6 +171,12 @@ class SQInterface:
         self.dut.i_data_update.value = 0
         self.dut.i_commit_valid.value = 0
         self.dut.i_commit_rob_tag.value = 0
+        self.dut.i_commit_valid_comb.value = 0
+        self.dut.i_commit_rob_tag_comb.value = 0
+        self.dut.i_commit_valid_2.value = 0
+        self.dut.i_commit_rob_tag_2.value = 0
+        self.dut.i_commit_valid_comb_2.value = 0
+        self.dut.i_commit_rob_tag_comb_2.value = 0
         self.dut.i_sq_check_valid.value = 0
         self.dut.i_sq_check_addr.value = 0
         # Port-split replica — same value as i_sq_check_addr (drives upper
@@ -214,13 +220,63 @@ class SQInterface:
             is_mmio=is_mmio,
         )
 
+    def drive_alloc_2(
+        self,
+        rob_tag: int,
+        is_fp: bool = False,
+        size: int = 2,
+        is_sc: bool = False,
+        addr_valid: bool = False,
+        address: int = 0,
+        is_mmio: bool = False,
+    ) -> None:
+        """Drive slot-2 allocation request."""
+        self.dut.i_alloc_2.value = pack_sq_alloc(
+            valid=True,
+            rob_tag=rob_tag,
+            is_fp=is_fp,
+            size=size,
+            is_sc=is_sc,
+            addr_valid=addr_valid,
+            address=address,
+            is_mmio=is_mmio,
+        )
+
     def clear_alloc(self) -> None:
         """Clear allocation request."""
         self.dut.i_alloc.value = 0
 
+    def clear_alloc_2(self) -> None:
+        """Clear slot-2 allocation request."""
+        self.dut.i_alloc_2.value = 0
+
     # =========================================================================
     # Address Update
     # =========================================================================
+
+    def drive_early_addr_update(
+        self, rob_tag: int, address: int, is_mmio: bool = False
+    ) -> None:
+        """Drive slot-1 early address update."""
+        self.dut.i_early_addr_update.value = pack_sq_addr_update(
+            valid=True, rob_tag=rob_tag, address=address, is_mmio=is_mmio
+        )
+
+    def clear_early_addr_update(self) -> None:
+        """Clear slot-1 early address update."""
+        self.dut.i_early_addr_update.value = 0
+
+    def drive_early_addr_update_2(
+        self, rob_tag: int, address: int, is_mmio: bool = False
+    ) -> None:
+        """Drive slot-2 early address update."""
+        self.dut.i_early_addr_update_2.value = pack_sq_addr_update(
+            valid=True, rob_tag=rob_tag, address=address, is_mmio=is_mmio
+        )
+
+    def clear_early_addr_update_2(self) -> None:
+        """Clear slot-2 early address update."""
+        self.dut.i_early_addr_update_2.value = 0
 
     def drive_addr_update(
         self, rob_tag: int, address: int, is_mmio: bool = False
@@ -257,9 +313,36 @@ class SQInterface:
         self.dut.i_commit_valid.value = 1
         self.dut.i_commit_rob_tag.value = rob_tag & MASK_TAG
 
+    def drive_commit_comb(self, rob_tag: int) -> None:
+        """Drive same-cycle combinational commit guard for slot 1."""
+        self.dut.i_commit_valid_comb.value = 1
+        self.dut.i_commit_rob_tag_comb.value = rob_tag & MASK_TAG
+
+    def drive_commit_2(self, rob_tag: int) -> None:
+        """Drive widen-commit slot-2 signal for a store."""
+        self.dut.i_commit_valid_2.value = 1
+        self.dut.i_commit_rob_tag_2.value = rob_tag & MASK_TAG
+
+    def drive_commit_comb_2(self, rob_tag: int) -> None:
+        """Drive same-cycle combinational commit guard for slot 2."""
+        self.dut.i_commit_valid_comb_2.value = 1
+        self.dut.i_commit_rob_tag_comb_2.value = rob_tag & MASK_TAG
+
     def clear_commit(self) -> None:
         """Clear commit signal."""
         self.dut.i_commit_valid.value = 0
+
+    def clear_commit_comb(self) -> None:
+        """Clear same-cycle combinational commit guard for slot 1."""
+        self.dut.i_commit_valid_comb.value = 0
+
+    def clear_commit_2(self) -> None:
+        """Clear widen-commit slot-2 signal."""
+        self.dut.i_commit_valid_2.value = 0
+
+    def clear_commit_comb_2(self) -> None:
+        """Clear same-cycle combinational commit guard for slot 2."""
+        self.dut.i_commit_valid_comb_2.value = 0
 
     # =========================================================================
     # Store-to-Load Forwarding Check
@@ -357,6 +440,11 @@ class SQInterface:
     def full(self) -> bool:
         """Return whether the store queue is full."""
         return bool(self.dut.o_full.value)
+
+    @property
+    def full_for_2(self) -> bool:
+        """Return whether there is room for fewer than two new entries."""
+        return bool(self.dut.o_full_for_2.value)
 
     @property
     def empty(self) -> bool:

--- a/verif/cocotb_tests/tomasulo/store_queue/test_store_queue.py
+++ b/verif/cocotb_tests/tomasulo/store_queue/test_store_queue.py
@@ -205,6 +205,144 @@ async def test_alloc_with_initial_address(dut: Any) -> None:
 
 
 # ============================================================================
+# Test 2c: Slot-2-only allocation with initial address
+# ============================================================================
+@cocotb.test()
+async def test_slot2_only_alloc_with_initial_address(dut: Any) -> None:
+    """A slot-2-only store allocates the next free entry and drains normally."""
+    dut_if, model = await setup(dut)
+
+    dut_if.drive_alloc_2(
+        rob_tag=9,
+        size=MEM_SIZE_WORD,
+        addr_valid=True,
+        address=0x1090,
+    )
+    model.alloc(9, False, MEM_SIZE_WORD, addr_valid=True, address=0x1090)
+    await dut_if.step()
+    dut_if.clear_alloc_2()
+
+    assert dut_if.count == 1, f"Expected one slot-2-only entry, got {dut_if.count}"
+
+    dut_if.drive_data_update(9, 0x55667788)
+    model.data_update(9, 0x55667788)
+    await dut_if.step()
+    dut_if.clear_data_update()
+
+    write_req = await commit_and_write(dut_if, model, rob_tag=9)
+
+    assert write_req.addr == 0x1090
+    assert write_req.data == 0x55667788
+    assert dut_if.empty, "SQ should be empty after slot-2-only store drains"
+
+
+# ============================================================================
+# Test 2d: Dual allocation, dual early-address update, and widen commit
+# ============================================================================
+@cocotb.test()
+async def test_slot1_slot2_dual_alloc_early_addr_and_widen_commit(dut: Any) -> None:
+    """Slot-1/slot-2 stores can capture early addresses and commit together."""
+    dut_if, model = await setup(dut)
+
+    dut_if.drive_alloc(rob_tag=4, size=MEM_SIZE_WORD)
+    dut_if.drive_alloc_2(rob_tag=5, size=MEM_SIZE_WORD)
+    model.alloc(4, False, MEM_SIZE_WORD)
+    model.alloc(5, False, MEM_SIZE_WORD)
+    await dut_if.step()
+    dut_if.clear_alloc()
+    dut_if.clear_alloc_2()
+
+    assert dut_if.count == 2, f"Expected two allocated stores, got {dut_if.count}"
+
+    dut_if.drive_early_addr_update(rob_tag=4, address=0x2040)
+    dut_if.drive_early_addr_update_2(rob_tag=5, address=0x2044)
+    model.addr_update(4, 0x2040)
+    model.addr_update(5, 0x2044)
+    await dut_if.step()
+    dut_if.clear_early_addr_update()
+    dut_if.clear_early_addr_update_2()
+
+    dut_if.drive_data_update(4, 0xAAAA_0004)
+    model.data_update(4, 0xAAAA_0004)
+    await dut_if.step()
+    dut_if.clear_data_update()
+
+    dut_if.drive_data_update(5, 0xBBBB_0005)
+    model.data_update(5, 0xBBBB_0005)
+    await dut_if.step()
+    dut_if.clear_data_update()
+
+    dut_if.drive_commit(4)
+    dut_if.drive_commit_2(5)
+    model.commit(4)
+    model.commit(5)
+    await dut_if.step()
+    dut_if.clear_commit()
+    dut_if.clear_commit_2()
+
+    first = await complete_mem_write(dut_if, model)
+    assert first.addr == 0x2040
+    assert first.data == 0xAAAA_0004
+
+    second = await complete_mem_write(dut_if, model)
+    assert second.addr == 0x2044
+    assert second.data == 0xBBBB_0005
+
+    assert dut_if.empty, "SQ should be empty after both widened stores drain"
+
+
+# ============================================================================
+# Test 2e: Slot-2 store is newest forwarding candidate
+# ============================================================================
+@cocotb.test()
+async def test_slot2_store_forwarding_newest_wins(dut: Any) -> None:
+    """A same-cycle slot-2 store forwards over its older slot-1 peer."""
+    dut_if, model = await setup(dut)
+
+    store_addr = 0x2080
+
+    dut_if.drive_alloc(rob_tag=6, size=MEM_SIZE_WORD)
+    dut_if.drive_alloc_2(rob_tag=7, size=MEM_SIZE_WORD)
+    model.alloc(6, False, MEM_SIZE_WORD)
+    model.alloc(7, False, MEM_SIZE_WORD)
+    await dut_if.step()
+    dut_if.clear_alloc()
+    dut_if.clear_alloc_2()
+
+    dut_if.drive_early_addr_update(rob_tag=6, address=store_addr)
+    dut_if.drive_early_addr_update_2(rob_tag=7, address=store_addr)
+    model.addr_update(6, store_addr)
+    model.addr_update(7, store_addr)
+    await dut_if.step()
+    dut_if.clear_early_addr_update()
+    dut_if.clear_early_addr_update_2()
+
+    dut_if.drive_data_update(6, 0x1111_0006)
+    model.data_update(6, 0x1111_0006)
+    await dut_if.step()
+    dut_if.clear_data_update()
+
+    dut_if.drive_data_update(7, 0x2222_0007)
+    model.data_update(7, 0x2222_0007)
+    await dut_if.step()
+    dut_if.clear_data_update()
+
+    dut_if.drive_rob_head_tag(0)
+    dut_if.drive_sq_check(addr=store_addr, rob_tag=8, size=MEM_SIZE_WORD)
+    await dut_if.step()
+
+    fwd = dut_if.read_sq_forward()
+    all_known = dut_if.read_all_older_addrs_known()
+
+    assert all_known, "Both older slot stores have known addresses"
+    assert fwd.match, "Load should match the same-address stores"
+    assert fwd.can_forward, "Newest slot-2 store should be forwardable"
+    assert fwd.data == 0x2222_0007, f"Expected slot-2 data, got 0x{fwd.data:x}"
+
+    dut_if.clear_sq_check()
+
+
+# ============================================================================
 # Test 3: Allocate to full
 # ============================================================================
 @cocotb.test()


### PR DESCRIPTION
  Add load queue tests for slot-2-only allocation and paired slot1/slot2
  allocation through completion.

  Add store queue tests for slot-2-only allocation and drain, dual early
  address updates with widened commit, and newest-store forwarding from
  slot 2. Extend the cocotb interfaces with the needed slot-2 helpers and
  initialize SQ commit-side inputs explicitly.

  Update the LQ README verification note to reflect the new coverage.