### PR TITLE
docs: refresh architecture diagrams and README details

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,31 +23,29 @@ back-end, M/S/U privilege modes with trap delegation, and Sv39 virtual memory.
 
 ### Architecture Outline
 
-```
-IF -> PD -> ID -> dispatch -> Tomasulo back-end -> commit
- │    │    │        │          │                  └─ ROB commit to INT/FP regfiles
- │    │    │        │          ├─ ROB, RAT, reservation stations, CDB
- │    │    │        │          └─ Load queue, store queue, FU shims
- │    │    │        └─ Rename and resource allocation
- │    │    └─ Instruction decode, CSR reads, branch target precompute
- │    └─ Pre-decode and C-extension decompression
- └─ Instruction fetch, branch prediction, return address stack
-```
+The shared [architecture diagram](docs/diagrams/frost-architecture.svg) shows
+the CPU and X3 memory/system interfaces. IF, PD and ID form a two-wide
+front-end feeding dispatch and register renaming. Six reservation stations
+schedule execution; results broadcast over two CDB lanes, and the ROB
+commits up to two instructions in program order. CSR instructions are
+decoded in ID, but CSR reads and writes execute at commit.
 
 ### Design Principles
 
-The core CPU uses no vendor-specific primitives; board wrappers may. Critical
-paths are managed with registered outputs. Verification is Cocotb directed
+The core provides portable SystemVerilog implementations; Xilinx builds can
+select primitive-backed RAM and timing paths. Critical paths are managed
+with registered outputs. Verification includes Cocotb directed
 tests, riscv-tests and riscv-arch-test compliance, and Spike-referenced random
 torture, mirrored across the `bram` and `ddr` memory tiers and all run under
 Verilator.
 
 ### Memory Map
 
-| Address Range | Description |
-|---------------|-------------|
-| `0x0000_0000` | ROM: code and read-only data, fast BRAM (95 KiB) |
+| Region Base | Description |
+|-------------|-------------|
+| `0x0000_0000` | Low BRAM: 256 KiB for uncached code, data, stack and debug regions |
 | `0x4000_0000` | MMIO region (UART, FIFOs, CLINT-style timer) |
+| `0x4400_0000` | PLIC: external interrupts, hart 0 M and S contexts |
 | `0x8000_0000` | DDR: cached region for code (`.ddr_text`), heap, and large data (1 GiB) |
 
 `hw/rtl/README.md` has the full memory map, including the RAM, debug, and PLIC
@@ -74,7 +72,7 @@ The [main README](README.md#prerequisites) lists the validated tool versions.
    ```
 
 2. Initialize the submodules (FreeRTOS, CoreMark, CoreMark-PRO, riscv-tests,
-   riscv-arch-test, and Buildroot):
+   riscv-arch-test, Buildroot, and OpenSBI):
    ```bash
    git submodule update --init --recursive
    ```
@@ -272,7 +270,8 @@ assign cache_hit = (tag_stored == tag_incoming);
 
 #### Portability Requirements
 
-- No vendor-specific primitives in the core CPU (`hw/rtl/cpu_and_mem/`)
+- Preserve a portable implementation for core CPU paths (`hw/rtl/cpu_and_mem/`);
+  gate optional Xilinx primitives with `FROST_XILINX_PRIMS`
 - Synthesis attributes are fine as optimization hints
 - Board-specific code lives in `boards/`
 - Library primitives in `hw/rtl/lib/` are generic or have a vendor alternative

--- a/README.md
+++ b/README.md
@@ -36,58 +36,20 @@ at 300 MHz on the Alveo X3. The core is portable SystemVerilog written for FPGAs
   signals, fork/exec, futex, LR/SC contention) must pass before the login
   prompt. The image boots on X3 hardware, and `fpga/linux_boot_soak.py` scores
   the same payload across repeated hardware boots.
-- Portable core RTL. The CPU avoids vendor primitives and passes generic Yosys
-  coarse synthesis plus a full UltraScale+ synthesis target. The board
+- Portable core RTL. The CPU provides portable implementations and passes
+  generic Yosys coarse synthesis plus a full UltraScale+ synthesis target.
+  Xilinx builds can select primitive-backed RAM and timing paths. The board
   integration keeps board-specific wrappers separate from the common Xilinx
   subsystem.
 - Apache 2.0 license, suitable for commercial and academic use.
 
 ## Features
 
-```
-┌──────────────────────────────────────────────────────────────────────────────┐
-│                              FROST RISC-V CPU                                │
-├──────────────────────────────────────────────────────────────────────────────┤
-│                                                                              │
-│   In-order front-end                                                         │
-│   ┌────┐   ┌────┐   ┌────┐    2-wide dispatch / rename / resource alloc      │
-│   │ IF │──>│ PD │──>│ ID │──────────────────────────────┐                    │
-│   └────┘   └────┘   └────┘                              │                    │
-│     ▲      C-ext     CSR dec                            ▼                    │
-│     │      expand                          ┌─────────────────────────────┐   │
-│     │                                      │   ROB  (32 entries)         │   │
-│     │   ┌────────────────┐                 │   RAT  (INT + FP, 8 ckpts)  │   │
-│     │   │ BTB 256×2b     │                 └──────────────┬──────────────┘   │
-│     │   │ DirPred 1024×2b│                                │ issue            │
-│     │   │ RAS 8          │                                ▼                  │
-│     │   └────────────────┘     ┌──────────────────────────────────────────┐  │
-│     │                          │  6 reservation stations                  │  │
-│     │                          │  INT  MUL  MEM  FP  FMUL  FDIV           │  │
-│     │                          │  (8)  (4)  (8)  (6)  (4)   (2)           │  │
-│     │                          └──────────────┬───────────────────────────┘  │
-│     │                                         ▼                              │
-│     │                          FU shims (ALU x2, MUL/DIV, FPU)               │
-│     │                          LQ + L0 cache, SQ                             │
-│     │                                         │                              │
-│     │                                         ▼                              │
-│     │                          CDB (2 lanes, fixed priority)                 │
-│     │                          broadcasts results; wakes RS, marks ROB done  │
-│     │                                         │                              │
-│     │                                         ▼                              │
-│     │                            commit ──> INT / FP regfiles                │
-│     │                                        SQ release, trap, redirect      │
-│     │                                                                        │
-│     └─── early mispredict recovery (~2 cycles): redirect IF + restore RAT    │
-│                                                                              │
-│   ┌──────────────────────────┐    ┌─────────────────────────────────────┐    │
-│   │ Trap Unit                │    │ Peripherals                         │    │
-│   │ (M/S/U traps, delegation,│    │ UART (+ ns16550a face), FIFO0/1     │    │
-│   │  mret/sret, wfi,         │    │ CLINT timer (mtime/mtimecmp, msip)  │    │
-│   │  interrupts, exceptions) │    │ PLIC (hart 0 M and S contexts)      │    │
-│   └──────────────────────────┘    └─────────────────────────────────────┘    │
-│                                                                              │
-└──────────────────────────────────────────────────────────────────────────────┘
-```
+[![FROST architecture: two-wide out-of-order CPU, Sv39 translation, X3 cache hierarchy, and system peripherals](docs/diagrams/frost-architecture.svg)](docs/diagrams/frost-architecture.svg)
+
+Matching **I** (instruction) and **D** (data) badges connect the CPU and system
+views. Cache capacities show the X3 configuration; only selected connections
+are drawn. Click the diagram to view it at full size.
 
 ### Supported RISC-V Extensions
 
@@ -148,11 +110,11 @@ at 300 MHz on the Alveo X3. The core is portable SystemVerilog written for FPGAs
   path of about two cycles that redirects the front-end and restores the RAT
   in the same cycle. JALR mispredictions and exceptions take the slower
   commit-time path.
-- Branch prediction with a 256-entry 2-bit BTB (trained for conditional
-  branches and JAL, with slot-2 lookup), a 1024-entry bimodal direction
-  predictor, an 8-entry return address stack, and PD-stage computed-target
-  redirects for conditional branches that miss the BTB but are predicted
-  taken.
+- Branch prediction uses a 256-entry BTB with 2-bit direction counters
+  (trained for conditional branches and JAL, with slot-2 lookup), a 1024-entry
+  bimodal direction predictor, an 8-entry return address stack, and PD-stage
+  computed-target redirects for conditional branches that miss the BTB but
+  are predicted taken.
 - L0 cache inside the load queue, cutting load-use latency: 128 entries,
   direct-mapped, dword-granular, filled from load responses. A store
   invalidates its dword line when its memory write launches.
@@ -165,6 +127,9 @@ at 300 MHz on the Alveo X3. The core is portable SystemVerilog written for FPGAs
 - CLINT-compatible timer (mtime/mtimecmp) for preemptive scheduling, and a
   PLIC with M and S contexts for hart 0 whose sources are the ns16550 UART
   and the board's external-interrupt pin.
+- RISC-V debug over JTAG: a debug transport module (DTM) connects to the
+  debug module for halt, resume, and single-step. X3 uses the FPGA's BSCAN
+  USER chains; the portable integration provides a generic JTAG TAP.
 - Separate instruction and data memory ports (Harvard).
 - Write-back cache hierarchy over DDR. A 1 GiB cached region at `0x8000_0000`
   is served by `frost_cache` instances: direct-mapped, 32 B lines, write-back

--- a/boards/README.md
+++ b/boards/README.md
@@ -1,7 +1,7 @@
 # FROST FPGA Board Support
 
-Each board subdirectory holds that board's clock generation, pin constraints,
-top-level wrapper, and Xilinx IP setup.
+Each board subdirectory holds its top-level RTL wrapper, synthesis file list,
+and pin constraints. Xilinx IP generation lives under `fpga/build/`.
 
 ## Supported Boards
 
@@ -24,65 +24,32 @@ releases the reset. All nine CoreMark-PRO workloads run on X3.
 
 ## Architecture Overview
 
-Each board wrapper handles clock generation and instantiates a common `xilinx_frost_subsystem` module:
+The X3 top instantiates the common `xilinx_frost_subsystem` beside the
+`ddr_subsys` block design. The common subsystem contains the low-BRAM
+loader, BSCAN chains, reset timers, and the `frost` wrapper; the DDR block
+design contains its own JTAG-AXI loader, SmartConnect, and DDR4 controller.
 
-```
-┌───────────────────────────────────────────────────────────────────────────┐
-│                           Board Top Module                                │
-│                              (x3_frost)                                   │
-│                                                                           │
-│  ┌─────────────────────────────────────────────────────────────────────┐  │
-│  │                        Clock Generation                             │  │
-│  │                                                                     │  │
-│  │  Clock      ┌────────┐   ┌──────┐   ┌────────┐                      │  │
-│  │  Input ────>│ IBUF/  │──>│ MMCM │──>│  BUFG  │──> CPU Clock         │  │
-│  │             │ IBUFDS │   └──┬───┘   └────────┘    (300 MHz)         │  │
-│  │             └────────┘      │                                       │  │
-│  │                             └──────>┌────────┐                      │  │
-│  │                                     │  BUFG  │──> /4 Clock          │  │
-│  │                                     └────────┘    (75 MHz)          │  │
-│  └─────────────────────────────────────────────────────────────────────┘  │
-│                                                                           │
-│  ┌─────────────────────────────────────────────────────────────────────┐  │
-│  │                    xilinx_frost_subsystem                           │  │
-│  │                                                                     │  │
-│  │  ┌───────────────────────────────────────────────────────────────┐  │  │
-│  │  │                  JTAG Software Loading (/4 clock)             │  │  │
-│  │  │                                                               │  │  │
-│  │  │  JTAG     ┌─────────────┐  AXI   ┌─────────────────┐          │  │  │
-│  │  │  Port ───>│ jtag_axi_0  │───────>│ axi_bram_ctrl_0 │          │  │  │
-│  │  │           └─────────────┘        └────────┬────────┘          │  │  │
-│  │  │                                           │                   │  │  │
-│  │  │      ┌────────────────────────────────────┘                   │  │  │
-│  │  │      │  BRAM Interface                                        │  │  │
-│  │  │      v  (en, we, addr, wrdata)                                │  │  │
-│  │  └──────┼────────────────────────────────────────────────────────┘  │  │
-│  │         │                                                           │  │
-│  │  ┌──────┼────────────────────────────────────────────────────────┐  │  │
-│  │  │      │                    FROST CPU                           │  │  │
-│  │  │      v                                                        │  │  │
-│  │  │  ┌─────────────┐   ┌────────────────────┐   ┌─────────────┐   │  │  │
-│  │  │  │  Low BRAM   │<──│  FROST OOO CPU     │   │  UART TX    │───┼──┼─>│
-│  │  │  │ code/data   │   │ (IF-PD-ID+Tomasulo)│   │  UART RX    │<──┼──┼──│
-│  │  │  │  + loader   │   └────────────────────┘   └─────────────┘   │  │  │
-│  │  │  └─────────────┘                                              │  │  │
-│  │  │                                                               │  │  │
-│  │  │  ┌─────────────────────────────────────────────────────────┐  │  │  │
-│  │  │  │ Image Load Reset Logic                                  │  │  │  │
-│  │  │  │ • Detects JTAG software-image loads                     │  │  │  │
-│  │  │  │ • Holds CPU in reset during software loading            │  │  │  │
-│  │  │  │ • Releases reset after counter expires                  │  │  │  │
-│  │  │  └─────────────────────────────────────────────────────────┘  │  │  │
-│  │  └───────────────────────────────────────────────────────────────┘  │  │
-│  └─────────────────────────────────────────────────────────────────────┘  │
-│                                                                           │
-└───────────────────────────────────────────────────────────────────────────┘
-```
+[![X3 board integration: CPU and divided clocks, separate BRAM and DDR loaders, BSCAN debug, shared DDR AXI, and reset sequencing](../docs/diagrams/x3-board-integration.svg)](../docs/diagrams/x3-board-integration.svg)
 
-The diagram is simplified. Low BRAM is the uncached region, with the
-instruction-metadata latency split described above. High-address instruction
-fetch and data accesses go through the L1I/L1D cache hierarchy and the board's
-DDR subsystem.
+Module boundaries are shown; individual modules span several clock domains.
+The core and runtime memory ports use the CPU clock, while UART, software
+loading, and the common subsystem's reset timers use CPU clock/4. BSCAN and
+the DTM transport use JTAG TCK and cross into the CPU domain. SmartConnect
+bridges the CPU, /4, and independent DDR UI clocks; the DDR controller has a
+separate 300 MHz reference input.
+
+The cache bridge presents 256-bit AXI with addresses relative to the cached
+region. SmartConnect combines it with the DDR JTAG master and converts to
+the controller's 512-bit memory AXI interface. The first 1 GiB is mapped at
+CPU address `0x8000_0000`; the controller's ECC management interface is
+reachable only from the DDR JTAG master, at region offset `0x4000_0000`.
+
+DDR calibration passes through a two-flop synchronizer in `x3_frost` before
+releasing the common subsystem reset. DDR transport reset depends on MMCM
+lock; startup and image-load holds apply separately inside the common
+subsystem. The diagram selects the board-level connections; see the
+[CPU architecture diagram](../docs/diagrams/frost-architecture.svg) for the
+core and cache hierarchy.
 
 ## JTAG-based software loading
 
@@ -103,7 +70,10 @@ hardware-manager Tcl flow) for each new image. One load runs as follows:
 The image-load reset in `xilinx_frost_subsystem` runs on the /4 clock. Every
 low-BRAM write asserts the CPU reset and restarts a 27-bit cycle counter, so
 the CPU is released about 1.8 s after the last write on X3's 75 MHz /4 clock
-and never executes a partial or stale image.
+with the loading sequence above keeping it in reset throughout the transfer.
+A 16-bit startup counter also delays the programming IP and CPU after the
+board reset releases. `frost` then synchronizes its combined reset into the
+CPU and /4 domains.
 
 ## RISC-V debug over BSCAN (OpenOCD)
 
@@ -124,7 +94,7 @@ boards/
 ├── README.md                    # This file
 ├── xilinx_frost_subsystem.sv    # Common subsystem (JTAG loader, BSCAN debug chains, BRAM, CPU, reset)
 └── x3/
-    ├── x3_frost.sv              # Top-level board wrapper (clock generation)
+    ├── x3_frost.sv              # Clocks, DDR integration, calibration/reset, common subsystem
     ├── x3_frost.f               # File list for synthesis tools
     └── constr/
         └── x3.xdc               # Pin assignments & timing constraints
@@ -168,9 +138,9 @@ For manual Vivado project setup:
 
 After the FPGA is programmed with the bitstream:
 
-1. Build the application under `sw/apps/<app>/`.
-2. Run `fpga/load_software/load_software.py <board> <app>`.
-3. The loader bursts the cached-region image (`sw_ddr.txt`, when non-empty)
+1. Run `fpga/load_software/load_software.py <board> <app>`. It rebuilds the
+   application for the selected board by default.
+2. The loader bursts the cached-region image (`sw_ddr.txt`, when non-empty)
    into DDR, then writes `sw.txt` to low BRAM; the CPU leaves reset once the
    image-load counter expires (see
    [JTAG-based software loading](#jtag-based-software-loading)).
@@ -202,8 +172,10 @@ that multiplies the MMCM output divide, so a functional-validation bitstream
 runs the CPU at 300/N MHz with the same RTL; the reference oscillator and the
 DDR4 controller clocking are unchanged.
 
-X3 divides the CPU clock with a `BUFGCE_DIV` to produce the 75 MHz /4 clock
-for the JTAG loader IP and UART.
+Two `BUFGCE_DIV` instances share the MMCM output: divide-by-one supplies the
+CPU clock, and divide-by-four supplies the loader IP, UART, and reset timers.
+The /4 clock is 75 MHz by default and 75/N MHz when `CPU_CLK_DIV=N`. The
+DDR controller's dedicated 300 MHz reference is independent of both.
 
 ## Adding Support for New Boards
 

--- a/docs/diagrams/cache-hierarchy.svg
+++ b/docs/diagrams/cache-hierarchy.svg
@@ -1,0 +1,133 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="1016" viewBox="0 0 1200 1016" role="img" aria-labelledby="title desc">
+  <title id="title">FROST cache hierarchy and tagged arbitration</title>
+  <desc id="desc">
+    The X3 configuration has a 128 KiB L1D and a read-only 16 KiB L1I, both
+    using BRAM, and a shared 2 MiB L2 with UltraRAM data and packed tags.
+    The shared Sv39 page-table walker serves ITLB and DTLB misses, keeps one
+    walk in flight and bypasses both L1 caches. A first two-input arbiter
+    prioritizes the walker over L1I; a second prioritizes L1D over that merged
+    port. Together they implement fixed priority L1D, then walker, then L1I.
+    Requests reach L2, the tagged-line-to-AXI4 bridge and X3 DDR4. Software
+    sees a 1 GiB cached region starting at 0x80000000. The arbiters prefix
+    transaction IDs so responses route to their source, and requests from
+    different ports can be outstanding together. All cache levels are
+    direct-mapped with 32-byte lines; L1D and L2 are write-back, write-allocate.
+    The separate L1-only unit-test configuration uses the same L1s, walker
+    port and arbiters, but bypasses L2 and connects the bridge to behavioral
+    memory. Full-system integration uses HAS_L2=1. Arrows follow requests;
+    the return paths and cache-maintenance control are omitted.
+  </desc>
+  <!--
+    Self-contained SVG; edit the text, boxes and paths directly.
+    Source map (paths relative to the repository root):
+      hw/rtl/lib/cache/frost_cache_hierarchy.sv: L1s, port order, ID prefixes,
+        optional L2, production cache geometry and tag/data memory selection.
+      hw/rtl/lib/cache/line_port_arbiter.sv: fixed priority and response routing.
+      hw/rtl/lib/cache/line_port_axi_bridge.sv: 256-bit single-beat AXI requests.
+      hw/rtl/lib/cache/frost_cache_test_harness.sv: both unit-test shapes.
+      hw/rtl/cpu_and_mem/cpu_and_mem.sv: HAS_L2=1 and cache/bridge integration.
+      hw/rtl/cpu_and_mem/cpu/cpu_ooo/cpu_ooo.sv: one shared page-table walker.
+      hw/rtl/frost.sv, boards/x3/x3_frost.sv: X3 capacities and DDR backing.
+  -->
+  <defs>
+    <linearGradient id="background" x2="1" y2="1">
+      <stop stop-color="#101e34"/>
+      <stop offset="1" stop-color="#080f1d"/>
+    </linearGradient>
+    <marker id="arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto">
+      <path d="M 1 1 L 9 5 L 1 9 Z" fill="#7ed8bc"/>
+    </marker>
+    <style>
+      text { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; fill: #edf3fc; }
+      .heading { font-size: 24px; font-weight: 650; }
+      .label { font-size: 20px; font-weight: 600; }
+      .body { font-size: 18px; fill: #bdcbde; }
+      .small { font-size: 17px; fill: #bdcbde; }
+      .section { font-size: 17px; font-weight: 650; letter-spacing: 1.5px; fill: #adbed5; }
+      .center { text-anchor: middle; }
+      .panel { fill: #101d30; stroke: #2b3c55; stroke-width: 1.5; }
+      .memory { fill: #16342f; stroke: #4b8674; stroke-width: 1.5; }
+      .arbiter { fill: #173148; stroke: #42748f; stroke-width: 1.5; }
+      .system { fill: #19273b; stroke: #4b607a; stroke-width: 1.5; }
+      .link { fill: none; stroke: #7ed8bc; stroke-width: 2; stroke-linejoin: round; stroke-linecap: round; marker-end: url(#arrow); }
+      .port { font-size: 17px; fill: #edc37d; }
+    </style>
+  </defs>
+  <rect width="1200" height="1016" rx="24" fill="url(#background)"/>
+  <rect x="44" y="36" width="5" height="57" rx="2.5" fill="#7ed8bc"/>
+  <text x="66" y="67" font-size="36" font-weight="750">Cache hierarchy</text>
+  <text x="67" y="94" class="body">FROST · tagged 32-byte line ports · X3 production configuration</text>
+  <text x="1136" y="65" class="label" text-anchor="end">HAS_L2 = 1</text>
+
+  <rect x="28" y="122" width="1144" height="676" rx="20" class="panel"/>
+  <text x="64" y="160" class="section">DATA ADAPTER</text>
+  <text x="448" y="160" class="section">ITLB + DTLB MISSES</text>
+  <text x="832" y="160" class="section">FETCH PROVIDER</text>
+  <g class="center">
+    <rect x="64" y="185" width="304" height="110" rx="12" class="memory"/>
+    <text x="216" y="220" class="heading">L1D · 128 KiB</text>
+    <text x="216" y="250" class="body">BRAM · non-blocking</text>
+    <text x="216" y="277" class="small">Write-back + write-allocate</text>
+    <rect x="448" y="185" width="304" height="110" rx="12" class="memory"/>
+    <text x="600" y="220" class="heading">Shared Sv39 walker</text>
+    <text x="600" y="250" class="body">Read-only · bypasses L1</text>
+    <text x="600" y="277" class="small">One walk in flight</text>
+    <rect x="832" y="185" width="304" height="110" rx="12" class="memory"/>
+    <text x="984" y="220" class="heading">L1I · 16 KiB</text>
+    <text x="984" y="250" class="body">Read-only · BRAM</text>
+    <text x="984" y="277" class="small">Two-line fetch buffer upstream</text>
+  </g>
+
+  <path d="M 600 295 V 352" class="link"/>
+  <path d="M 984 295 V 352" class="link"/>
+  <text x="616" y="337" class="port">Port 0</text>
+  <text x="1000" y="337" class="port">Port 1</text>
+  <rect x="544" y="352" width="592" height="96" rx="12" class="arbiter"/>
+  <text x="840" y="388" class="heading center">Walker / instruction arbiter</text>
+  <text x="840" y="419" class="body center">2:1 fixed priority · walker before L1I</text>
+
+  <path d="M 216 295 V 494" class="link"/>
+  <path d="M 840 448 V 494" class="link"/>
+  <text x="232" y="479" class="port">Port 0</text>
+  <text x="856" y="479" class="port">Port 1</text>
+  <rect x="64" y="494" width="1072" height="84" rx="12" class="arbiter"/>
+  <text x="600" y="529" class="heading center">Data / shared-port arbiter</text>
+  <text x="600" y="558" class="body center">2:1 fixed priority · combined order: L1D &gt; walker &gt; L1I</text>
+
+  <path d="M 224 578 V 624" class="link"/>
+  <text x="246" y="608" class="small">Tagged transactions · several may be in flight</text>
+  <g class="center">
+    <rect x="64" y="624" width="320" height="104" rx="12" class="memory"/>
+    <text x="224" y="657" class="heading">Shared L2 · 2 MiB</text>
+    <text x="224" y="686" class="body">UltraRAM data + packed tags</text>
+    <text x="224" y="713" class="small">Write-back + write-allocate</text>
+    <path d="M 384 676 H 440" class="link"/>
+    <rect x="440" y="624" width="320" height="104" rx="12" class="memory"/>
+    <text x="600" y="657" class="heading">Tagged line → AXI4</text>
+    <text x="600" y="686" class="body">256-bit single-beat requests</text>
+    <text x="600" y="713" class="small">Multiple transactions in flight</text>
+    <path d="M 760 676 H 816" class="link"/>
+    <rect x="816" y="624" width="320" height="104" rx="12" class="memory"/>
+    <text x="976" y="657" class="heading">X3 DDR4</text>
+    <text x="976" y="686" class="body">1 GiB cached region</text>
+    <text x="976" y="713" class="small">Base: 0x8000_0000</text>
+  </g>
+  <text x="600" y="763" class="small center">L1I / L1D / L2: direct-mapped, 32 B lines. Responses route back using prefixed transaction IDs.</text>
+  <text x="600" y="787" class="small center">Arrows follow requests; response and maintenance-control paths are omitted.</text>
+
+  <text x="64" y="843" class="section">L1-ONLY UNIT CONFIGURATION / HAS_L2 = 0</text>
+  <g class="center">
+    <rect x="64" y="867" width="304" height="87" rx="12" class="system"/>
+    <text x="216" y="901" class="label">Same three upstream ports</text>
+    <text x="216" y="930" class="body">L1D + walker + L1I · arbiters</text>
+    <path d="M 368 910 H 448" class="link"/>
+    <rect x="448" y="867" width="304" height="87" rx="12" class="system"/>
+    <text x="600" y="901" class="label">AXI bridge</text>
+    <text x="600" y="930" class="body">L2 is bypassed</text>
+    <path d="M 752 910 H 832" class="link"/>
+    <rect x="832" y="867" width="304" height="87" rx="12" class="system"/>
+    <text x="984" y="901" class="label">Behavioral memory</text>
+    <text x="984" y="930" class="body">Focused cache unit benches</text>
+  </g>
+  <text x="64" y="990" class="small">The lower-level hierarchy supports both shapes; full-system integration uses L2.</text>
+</svg>

--- a/docs/diagrams/frost-architecture.svg
+++ b/docs/diagrams/frost-architecture.svg
@@ -1,0 +1,330 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="1576" viewBox="0 0 1200 1576" role="img" aria-labelledby="title desc">
+  <title id="title">FROST CPU and X3 memory architecture</title>
+  <desc id="desc">
+    RV64GCB out-of-order CPU. IF, PD and ID feed two-wide dispatch and INT/FP
+    register renaming with eight branch checkpoints. Dispatch allocates the
+    32-entry reorder buffer, six reservation stations, and memory queues.
+    The INT, MUL, FP, FMUL, FDIV and MEM stations have 8, 4, 6, 4, 2 and 8
+    entries. INT issues to two ALUs; pipe 0 resolves branches. Other stations
+    serve integer multiply/divide, floating-point add/compare/convert,
+    multiply/FMA, divide/square root, and memory operations. Two CDB lanes
+    broadcast results to the reservation stations and ROB. The ROB commits
+    up to two instructions in order to INT/FP register files and releases
+    stores. CSR accesses execute at commit; traps support M/S/U delegation.
+    Conditional-branch mispredictions redirect fetch and restore the RAT in
+    about two cycles; JALR mispredictions and traps recover at commit.
+    Sv39 uses an eight-entry ITLB in IF and a 16-entry DTLB ahead of the
+    eight-entry load and store queues. The load queue contains a direct-mapped
+    128-entry, eight-byte-granule L0 cache and receives store forwarding.
+    Matching I and D badges connect the CPU to the system view below.
+    Cached instruction fetch uses a two-line fetch buffer and 16 KiB L1I;
+    cached data uses a 128 KiB L1D. One shared page-table walker serves both
+    TLBs and bypasses the L1 caches. Two tagged 2:1 line-port arbiters merge
+    L1D, walker and L1I traffic in that priority order into a 2 MiB UltraRAM
+    L2, then a 256-bit AXI bridge and the board DDR4 controller. Software sees
+    a 1 GiB cached region at 0x80000000. Uncached instruction/data accesses
+    use 256 KiB low BRAM; the data port also reaches UART, FIFO0/1, CLINT and
+    PLIC MMIO. JTAG connects through the DTM to the debug module for halt,
+    resume and single-step. Capacities show the X3 configuration. Only selected
+    connections are drawn; memory arrows follow requests, with responses omitted.
+  </desc>
+  <!--
+    Self-contained SVG; edit the text, boxes and paths directly.
+    Source map (paths relative to the repository root):
+      hw/rtl/cpu_and_mem/cpu/riscv_pkg.sv: ROB/RS/LQ/SQ/checkpoint capacities.
+      hw/rtl/cpu_and_mem/cpu/cpu_ooo/cpu_ooo.sv: dispatch, commit, shared PTW.
+      hw/rtl/cpu_and_mem/cpu/tomasulo/tomasulo_wrapper/tomasulo_wrapper.sv:
+        RS-to-FU routing, dual ALUs, both CDB lanes, DMMU, LQ/SQ and forwarding.
+      hw/rtl/cpu_and_mem/cpu/if_stage/branch_prediction/: BTB, bimodal, RAS.
+      hw/rtl/cpu_and_mem/cpu/mmu/{immu,dmmu}.sv: ITLB/DTLB integration.
+      hw/rtl/cpu_and_mem/cpu/tomasulo/load_queue/lq_l0_cache.sv: L0 geometry.
+      hw/rtl/cpu_and_mem/cpu_and_mem.sv: fetch buffer, memory, MMIO, debug.
+      hw/rtl/lib/cache/frost_cache_hierarchy.sv: D > walker > I tree and L2.
+      hw/rtl/frost.sv, boards/{xilinx_frost_subsystem,x3/x3_frost}.sv:
+        X3 cache/BRAM capacities and hardware DDR configuration.
+    Functional overview, not an exhaustive netlist or pipeline timing diagram.
+    The shared PTW is drawn in the memory view but instantiated in cpu_ooo.
+  -->
+  <defs>
+    <linearGradient id="background" x2="1" y2="1">
+      <stop stop-color="#101e34"/>
+      <stop offset="1" stop-color="#080f1d"/>
+    </linearGradient>
+    <linearGradient id="header-accent">
+      <stop stop-color="#62d8ef"/>
+      <stop offset="1" stop-color="#7f9cff"/>
+    </linearGradient>
+    <marker id="flow-arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M 1 1 L 9 5 L 1 9 Z" fill="#6dcee9"/>
+    </marker>
+    <marker id="result-arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M 1 1 L 9 5 L 1 9 Z" fill="#b5a1f8"/>
+    </marker>
+    <marker id="commit-arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M 1 1 L 9 5 L 1 9 Z" fill="#edc37d"/>
+    </marker>
+    <marker id="memory-arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M 1 1 L 9 5 L 1 9 Z" fill="#7ed8bc"/>
+    </marker>
+    <style>
+      text { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; fill: #edf3fc; }
+      .heading { font-size: 23px; font-weight: 650; }
+      .label { font-size: 20px; font-weight: 600; }
+      .body { font-size: 18px; fill: #bdcbde; }
+      .small { font-size: 17px; fill: #bdcbde; }
+      .section { font-size: 17px; font-weight: 650; letter-spacing: 1.6px; fill: #adbed5; }
+      .center { text-anchor: middle; }
+      .panel { fill: #101d30; stroke: #2b3c55; stroke-width: 1.5; }
+      .front { fill: #153149; stroke: #42748f; stroke-width: 1.5; }
+      .station { fill: #173148; stroke: #42748f; stroke-width: 1.5; }
+      .execution { fill: #16283d; stroke: #3b5573; stroke-width: 1.5; }
+      .result { fill: #2b2547; stroke: #8270b7; stroke-width: 1.5; }
+      .retire { fill: #332e27; stroke: #947b54; stroke-width: 1.5; }
+      .memory { fill: #16342f; stroke: #4b8674; stroke-width: 1.5; }
+      .system { fill: #19273b; stroke: #4b607a; stroke-width: 1.5; }
+      .flow { fill: none; stroke: #6dcee9; stroke-width: 2; stroke-linejoin: round; stroke-linecap: round; }
+      .broadcast { fill: none; stroke: #b5a1f8; stroke-width: 2; stroke-linejoin: round; stroke-linecap: round; }
+      .commit { fill: none; stroke: #edc37d; stroke-width: 2; stroke-linejoin: round; stroke-linecap: round; }
+      .memlink { fill: none; stroke: #7ed8bc; stroke-width: 2; stroke-linejoin: round; stroke-linecap: round; }
+      .port { fill: #7ed8bc; stroke: #101d30; stroke-width: 2; }
+      .port-text { font-size: 16px; font-weight: 750; fill: #0a221c; text-anchor: middle; }
+    </style>
+  </defs>
+
+  <rect width="1200" height="1576" rx="24" fill="url(#background)"/>
+  <rect x="44" y="37" width="5" height="57" rx="2.5" fill="url(#header-accent)"/>
+  <text x="66" y="68" font-size="38" font-weight="750" letter-spacing="1">FROST</text>
+  <text x="226" y="67" font-size="29" fill="#cbd8eb">Architecture</text>
+  <text x="67" y="94" class="body">Out-of-order RISC-V · RV64GCB · FPGA-native SystemVerilog</text>
+  <g class="small">
+    <circle cx="790" cy="56" r="4" fill="#6dcee9"/>
+    <text x="803" y="62">Instruction flow</text>
+    <circle cx="989" cy="56" r="4" fill="#b5a1f8"/>
+    <text x="1002" y="62">Results</text>
+    <circle cx="790" cy="86" r="4" fill="#edc37d"/>
+    <text x="803" y="92">Commit / control</text>
+    <circle cx="989" cy="86" r="4" fill="#7ed8bc"/>
+    <text x="1002" y="92">Memory</text>
+  </g>
+
+  <!-- CPU: dispatch allocates ROB and RS in parallel; RS issue to FUs. -->
+  <rect x="28" y="122" width="1144" height="770" rx="20" class="panel"/>
+  <text x="52" y="158" class="section">01 / CPU CORE</text>
+  <text x="1136" y="158" class="body" text-anchor="end">2-wide decode, dispatch and commit</text>
+
+  <rect x="80" y="184" width="672" height="30" rx="8" fill="#1b2a40"/>
+  <text x="416" y="205" class="small center">Prediction: BTB 256 entries · bimodal 1024 × 2b · RAS 8 entries</text>
+
+  <g id="front-end">
+    <rect x="80" y="230" width="208" height="100" rx="12" class="front"/>
+    <text x="104" y="261" class="heading">IF / Fetch</text>
+    <text x="104" y="288" class="body">64-bit window</text>
+    <text x="104" y="313" class="body">Sv39 ITLB · 8 entries</text>
+    <path d="M 288 280 H 312" class="flow" marker-end="url(#flow-arrow)"/>
+    <rect x="312" y="230" width="208" height="100" rx="12" class="front"/>
+    <text x="336" y="261" class="heading">PD / Predecode</text>
+    <text x="336" y="288" class="body">RVC decompression</text>
+    <text x="336" y="313" class="body">Early branch redirect</text>
+    <path d="M 520 280 H 544" class="flow" marker-end="url(#flow-arrow)"/>
+    <rect x="544" y="230" width="208" height="100" rx="12" class="front"/>
+    <text x="568" y="261" class="heading">ID / Decode</text>
+    <text x="568" y="288" class="body">Dual decode packets</text>
+    <text x="568" y="313" class="body">CSR decode</text>
+    <path d="M 752 280 H 786" class="flow" marker-end="url(#flow-arrow)"/>
+    <rect x="786" y="230" width="350" height="100" rx="12" class="front"/>
+    <text x="810" y="261" class="heading">Dispatch &amp; rename</text>
+    <text x="810" y="288" class="body">2-wide · INT + FP alias tables</text>
+    <text x="810" y="313" class="body">8 branch checkpoints</text>
+    <path d="M 80 288 H 65" class="memlink"/>
+    <circle cx="64" cy="288" r="13" class="port"/>
+    <text x="64" y="294" class="port-text">I</text>
+  </g>
+
+  <text x="80" y="373" class="section">6 RESERVATION STATIONS</text>
+  <text x="856" y="373" class="small" text-anchor="end">Independent issue</text>
+  <path d="M 884 330 V 391 H 138" class="flow"/>
+  <path d="M 1031 330 V 398" class="flow" marker-end="url(#flow-arrow)"/>
+  <g class="flow" marker-end="url(#flow-arrow)">
+    <path d="M 138 391 V 416"/>
+    <path d="M 270 391 V 416"/>
+    <path d="M 402 391 V 416"/>
+    <path d="M 534 391 V 416"/>
+    <path d="M 666 391 V 416"/>
+    <path d="M 798 391 V 416"/>
+  </g>
+  <!-- The enclosing bank is the destination of the CDB wakeup arrow. -->
+  <rect x="72" y="408" width="792" height="84" rx="14" fill="none" stroke="#54617c" stroke-dasharray="4 5"/>
+  <g id="reservation-stations" class="center">
+    <rect x="80" y="416" width="116" height="68" rx="10" class="station"/>
+    <text x="138" y="445" class="heading">INT</text>
+    <text x="138" y="471" class="small">8 entries</text>
+    <rect x="212" y="416" width="116" height="68" rx="10" class="station"/>
+    <text x="270" y="445" class="heading">MUL</text>
+    <text x="270" y="471" class="small">4 entries</text>
+    <rect x="344" y="416" width="116" height="68" rx="10" class="station"/>
+    <text x="402" y="445" class="heading">FP</text>
+    <text x="402" y="471" class="small">6 entries</text>
+    <rect x="476" y="416" width="116" height="68" rx="10" class="station"/>
+    <text x="534" y="445" class="heading">FMUL</text>
+    <text x="534" y="471" class="small">4 entries</text>
+    <rect x="608" y="416" width="116" height="68" rx="10" class="station"/>
+    <text x="666" y="445" class="heading">FDIV</text>
+    <text x="666" y="471" class="small">2 entries</text>
+    <rect x="740" y="416" width="116" height="68" rx="10" class="station"/>
+    <text x="798" y="445" class="heading">MEM</text>
+    <text x="798" y="471" class="small">8 entries</text>
+  </g>
+  <g class="flow" marker-end="url(#flow-arrow)">
+    <path d="M 138 484 V 510"/>
+    <path d="M 270 484 V 510"/>
+    <path d="M 402 484 V 510"/>
+    <path d="M 534 484 V 510"/>
+    <path d="M 666 484 V 510"/>
+    <path d="M 798 484 V 510"/>
+  </g>
+
+  <g id="execution" class="center">
+    <rect x="80" y="510" width="116" height="126" rx="10" class="execution"/>
+    <text x="138" y="545" class="label">ALU ×2</text>
+    <text x="138" y="575" class="small">Branch/JALR</text>
+    <text x="138" y="600" class="small">on pipe 0</text>
+    <rect x="212" y="510" width="116" height="126" rx="10" class="execution"/>
+    <text x="270" y="545" class="label">MUL / DIV</text>
+    <text x="270" y="575" class="small">Multiply</text>
+    <text x="270" y="600" class="small">Divide / rem.</text>
+    <rect x="344" y="510" width="116" height="126" rx="10" class="execution"/>
+    <text x="402" y="545" class="label">FP add</text>
+    <text x="402" y="575" class="small">Compare</text>
+    <text x="402" y="600" class="small">Convert</text>
+    <rect x="476" y="510" width="116" height="126" rx="10" class="execution"/>
+    <text x="534" y="545" class="label">FP mul</text>
+    <text x="534" y="575" class="small">Multiply</text>
+    <text x="534" y="600" class="small">FMA</text>
+    <rect x="608" y="510" width="116" height="126" rx="10" class="execution"/>
+    <text x="666" y="545" class="label">FP div</text>
+    <text x="666" y="575" class="small">Divide</text>
+    <text x="666" y="600" class="small">Square root</text>
+    <rect x="740" y="510" width="116" height="220" rx="10" class="memory"/>
+    <text x="798" y="543" class="label">DMMU</text>
+    <text x="798" y="571" class="small">DTLB · 16</text>
+    <path d="M 754 591 H 842" stroke="#4b8674"/>
+    <text x="790" y="619" class="label">LQ · 8</text>
+    <text x="790" y="646" class="small">+ L0 cache</text>
+    <text x="790" y="671" class="small">128 × 8 B</text>
+    <text x="790" y="712" class="label">SQ · 8</text>
+    <path d="M 828 704 H 846 V 617 H 830" class="memlink" marker-end="url(#memory-arrow)"/>
+  </g>
+  <path d="M 856 711 H 879" class="memlink"/>
+  <circle cx="879" cy="711" r="13" class="port"/>
+  <text x="879" y="717" class="port-text">D</text>
+
+  <g class="broadcast" marker-end="url(#result-arrow)">
+    <path d="M 138 636 V 664"/>
+    <path d="M 270 636 V 664"/>
+    <path d="M 402 636 V 664"/>
+    <path d="M 534 636 V 664"/>
+    <path d="M 666 636 V 664"/>
+  </g>
+  <rect x="80" y="664" width="644" height="66" rx="10" class="result"/>
+  <text x="402" y="692" class="label center">FU completion buffers / adapters</text>
+  <text x="402" y="718" class="small center">Buffered arithmetic completions · ungranted results wait</text>
+  <path d="M 402 730 V 756" class="broadcast" marker-end="url(#result-arrow)"/>
+  <path d="M 798 730 V 756" class="broadcast" marker-end="url(#result-arrow)"/>
+  <rect x="80" y="756" width="776" height="62" rx="12" class="result"/>
+  <text x="468" y="783" class="heading center">Common data bus · 2 result lanes</text>
+  <text x="468" y="806" class="small center">Fixed priority · wakes reservation stations + completes ROB entries</text>
+  <path d="M 80 787 H 58 V 450 H 72" class="broadcast" marker-end="url(#result-arrow)"/>
+  <path d="M 856 787 H 904 V 451 H 926" class="broadcast" marker-end="url(#result-arrow)"/>
+
+  <!-- Architectural state changes only through ordered retirement. -->
+  <g id="retirement" class="center">
+    <rect x="926" y="398" width="210" height="98" rx="12" class="retire"/>
+    <text x="1031" y="429" class="label">ROB · 32 entries</text>
+    <text x="1031" y="455" class="small">Results + exceptions</text>
+    <text x="1031" y="480" class="small">Program order</text>
+    <path d="M 1031 496 V 538" class="commit" marker-end="url(#commit-arrow)"/>
+    <rect x="926" y="538" width="210" height="98" rx="12" class="retire"/>
+    <text x="1031" y="569" class="heading">2-wide commit</text>
+    <text x="1031" y="596" class="small">In-order retirement</text>
+    <text x="1031" y="621" class="small">Release committed SQ</text>
+    <path d="M 1031 636 V 668" class="commit" marker-end="url(#commit-arrow)"/>
+    <rect x="926" y="668" width="210" height="70" rx="12" class="retire"/>
+    <text x="1031" y="697" class="label">INT / FP regfiles</text>
+    <text x="1031" y="724" class="small">2 write ports each</text>
+    <path d="M 1136 587 H 1151 V 812 H 1136" class="commit" marker-end="url(#commit-arrow)"/>
+    <rect x="926" y="776" width="210" height="92" rx="12" class="retire"/>
+    <text x="1031" y="805" class="label">CSRs + traps</text>
+    <text x="1031" y="832" class="small">CSR access at commit</text>
+    <text x="1031" y="855" class="small">M/S/U · delegation</text>
+  </g>
+  <text x="80" y="849" font-size="19" fill="#edc37d">Conditional-branch recovery ≈ 2 cycles: redirect fetch + restore RAT</text>
+  <text x="80" y="875" class="small">JALR mispredictions and traps recover at commit. Queue allocation occurs at dispatch.</text>
+
+  <!-- I/D badges connect the core ports above to the selected system paths. -->
+  <rect x="28" y="916" width="1144" height="626" rx="20" class="panel"/>
+  <text x="52" y="954" class="section">02 / MEMORY &amp; SYSTEM</text>
+  <text x="1136" y="954" class="body" text-anchor="end">Cache capacities shown for X3</text>
+
+  <circle cx="80" cy="990" r="13" class="port"/>
+  <text x="80" y="996" class="port-text">I</text>
+  <text x="104" y="996" class="body">Cached instruction fetch</text>
+  <text x="600" y="996" class="body center">ITLB + DTLB misses</text>
+  <circle cx="830" cy="990" r="13" class="port"/>
+  <text x="830" y="996" class="port-text">D</text>
+  <text x="854" y="996" class="body">Cached loads / stores</text>
+
+  <g id="l1-and-walker" class="center">
+    <rect x="64" y="1016" width="324" height="100" rx="12" class="memory"/>
+    <text x="226" y="1048" class="heading">Fetch buffer → L1I</text>
+    <text x="226" y="1075" class="body">2-line buffer · 16 KiB L1I</text>
+    <text x="226" y="1101" class="small">Read-only · BRAM</text>
+    <rect x="438" y="1016" width="324" height="100" rx="12" class="memory"/>
+    <text x="600" y="1048" class="heading">Shared Sv39 walker</text>
+    <text x="600" y="1075" class="body">Core page-table walker</text>
+    <text x="600" y="1101" class="small">Read-only port · bypasses L1</text>
+    <rect x="812" y="1016" width="324" height="100" rx="12" class="memory"/>
+    <text x="974" y="1048" class="heading">L1D · 128 KiB</text>
+    <text x="974" y="1075" class="body">Write-back + write-allocate</text>
+    <text x="974" y="1101" class="small">Non-blocking · BRAM</text>
+  </g>
+  <g class="memlink" marker-end="url(#memory-arrow)">
+    <path d="M 226 1116 V 1144"/>
+    <path d="M 600 1116 V 1144"/>
+    <path d="M 974 1116 V 1144"/>
+  </g>
+  <rect x="64" y="1144" width="1072" height="50" rx="10" class="memory"/>
+  <text x="600" y="1176" class="label center">Tagged line-port arbitration · L1D &gt; walker &gt; L1I · two 2:1 arbiters</text>
+  <path d="M 226 1194 V 1222" class="memlink" marker-end="url(#memory-arrow)"/>
+  <g id="l2-and-ddr" class="center">
+    <rect x="64" y="1222" width="324" height="88" rx="12" class="memory"/>
+    <text x="226" y="1258" class="heading">Shared L2 · 2 MiB</text>
+    <text x="226" y="1288" class="body">UltraRAM · write-back</text>
+    <path d="M 388 1266 H 438" class="memlink" marker-end="url(#memory-arrow)"/>
+    <rect x="438" y="1222" width="324" height="88" rx="12" class="memory"/>
+    <text x="600" y="1258" class="heading">256-bit AXI bridge</text>
+    <text x="600" y="1288" class="body">Multiple outstanding requests</text>
+    <path d="M 762 1266 H 812" class="memlink" marker-end="url(#memory-arrow)"/>
+    <rect x="812" y="1222" width="324" height="88" rx="12" class="memory"/>
+    <text x="974" y="1258" class="heading">DDR4 controller + DRAM</text>
+    <text x="974" y="1288" class="body">1 GiB region @ 0x8000_0000</text>
+  </g>
+  <text x="600" y="1338" class="small center">L1I / L1D / L2: direct-mapped, 32 B lines. Memory arrows show requests; responses return to their source.</text>
+
+  <path d="M 64 1359 H 1136" stroke="#2b3c55"/>
+  <text x="64" y="1388" class="section">UNCACHED PATHS &amp; DEBUG</text>
+  <g id="system-services">
+    <rect x="64" y="1404" width="324" height="112" rx="12" class="system"/>
+    <text x="84" y="1437" class="heading">I + D → low BRAM</text>
+    <text x="84" y="1467" class="body">256 KiB · uncached code + data</text>
+    <text x="84" y="1495" class="small">Base address: 0x0000_0000</text>
+    <rect x="438" y="1404" width="324" height="112" rx="12" class="system"/>
+    <text x="458" y="1437" class="heading">D → MMIO</text>
+    <text x="458" y="1467" class="body">UART / ns16550 · FIFO0/1</text>
+    <text x="458" y="1495" class="small">CLINT + PLIC → M/S interrupts</text>
+    <rect x="812" y="1404" width="324" height="112" rx="12" class="system"/>
+    <text x="832" y="1437" class="heading">JTAG debug</text>
+    <text x="832" y="1467" class="body">DTM → debug module → core</text>
+    <text x="832" y="1495" class="small">Halt · resume · single-step</text>
+  </g>
+  <text x="52" y="1564" font-size="16" fill="#a9bad0">Functional overview · selected connections · I / D badges link the two views</text>
+</svg>

--- a/docs/diagrams/tomasulo-backend.svg
+++ b/docs/diagrams/tomasulo-backend.svg
@@ -1,0 +1,256 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1120" height="1440" viewBox="0 0 1120 1440" role="img" aria-labelledby="title desc">
+  <title id="title">FROST Tomasulo back-end: allocation, execution, completion and commit</title>
+  <desc id="desc">
+    Two-wide dispatch renames INT and FP registers using eight checkpoints,
+    allocates the 32-entry ROB, and allocates the required reservation station
+    and load or store queue entries in parallel. Six reservation stations issue
+    independently: INT has eight entries and two ALU issue ports, MUL has four
+    entries for integer multiply and divide, FP has six entries, FMUL has four,
+    FDIV has two, and MEM has eight. Arithmetic shims feed completion adapters
+    independently of the memory path. Memory issue computes an address and
+    passes through the Sv39 DMMU with its 16-entry DTLB when translation is
+    active. The shared page-table walker lives outside the wrapper in cpu_ooo.
+    Loads use an eight-entry LQ with a 128 by 8-byte L0 cache. The eight-entry SQ
+    forwards older matching stores to loads and drains only committed stores.
+    The data-memory router serves caches, BRAM and MMIO. Load and atomic
+    results, and store faults, use the MEM completion slot. Ordinary successful
+    stores complete the ROB directly, bypassing the two CDB lanes. The CDB
+    broadcasts tags and results to wake all reservation stations and mark ROB
+    entries complete. The ROB retires up to two eligible instructions in order,
+    updating architectural registers, releasing stores and coordinating precise
+    CSR, trap and return effects. A badges mark entries allocated by dispatch;
+    S badges connect store retirement to SQ drain permission. Arrows show
+    selected logical paths, not pipeline latency or every handshake.
+  </desc>
+  <!--
+    Self-contained editable SVG. Source map, relative to repository root:
+      hw/rtl/cpu_and_mem/cpu/riscv_pkg.sv:
+        ROB/RS/LQ/SQ depths, checkpoint count and eight FU slots.
+      hw/rtl/cpu_and_mem/cpu/tomasulo/dispatch/dispatch.sv:
+        two-wide rename, ROB/RS/queue allocation and branch checkpoints.
+      hw/rtl/cpu_and_mem/cpu/tomasulo/tomasulo_wrapper/tomasulo_wrapper.sv:
+        six RS instances, two INT ALUs, independent FU adapters, CDB wakeup,
+        direct successful-store completion, DMMU and LQ/SQ update routing.
+      hw/rtl/cpu_and_mem/cpu/tomasulo/load_queue/lq_l0_cache.sv:
+        direct-mapped 128-entry, eight-byte-granule L0 cache.
+      hw/rtl/cpu_and_mem/cpu/tomasulo/load_queue/lq_issue_selector.sv:
+        older-store checks and head ordering for LR/AMO/device loads.
+      hw/rtl/cpu_and_mem/cpu/tomasulo/tomasulo_wrapper/atomics/sc_pending_unit.sv:
+        head-ordered SC completion and reservation check.
+      hw/rtl/cpu_and_mem/cpu/tomasulo/reorder_buffer/{reorder_buffer,rob_serializer}.sv:
+        CDB completion, two-wide eligible retirement and serializing effects.
+      hw/rtl/cpu_and_mem/cpu/cpu_ooo/cpu_ooo.sv:
+        shared PTW, architectural register files, commit and branch recovery.
+      hw/rtl/cpu_and_mem/cpu/cpu_ooo/memory_if/data_mem_request_router.sv:
+        SQ write, AMO write and LQ read arbitration into the external data port.
+    A and S are named connections, not hardware blocks or extra state.
+    The dispatch and architectural-state blocks are outside tomasulo_wrapper.
+  -->
+  <defs>
+    <linearGradient id="background" x2="1" y2="1">
+      <stop stop-color="#101e34"/>
+      <stop offset="1" stop-color="#080f1d"/>
+    </linearGradient>
+    <linearGradient id="accent">
+      <stop stop-color="#62d8ef"/>
+      <stop offset="1" stop-color="#7f9cff"/>
+    </linearGradient>
+    <marker id="flow-arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M 1 1 L 9 5 L 1 9 Z" fill="#6dcee9"/>
+    </marker>
+    <marker id="result-arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M 1 1 L 9 5 L 1 9 Z" fill="#b5a1f8"/>
+    </marker>
+    <marker id="commit-arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M 1 1 L 9 5 L 1 9 Z" fill="#edc37d"/>
+    </marker>
+    <marker id="memory-arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M 1 1 L 9 5 L 1 9 Z" fill="#7ed8bc"/>
+    </marker>
+    <style>
+      text { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; fill: #edf3fc; }
+      .heading { font-size: 24px; font-weight: 650; }
+      .label { font-size: 21px; font-weight: 600; }
+      .body { font-size: 19px; fill: #bdcbde; }
+      .small { font-size: 18px; fill: #bdcbde; }
+      .section { font-size: 17px; font-weight: 650; letter-spacing: 1.3px; fill: #adbed5; }
+      .center { text-anchor: middle; }
+      .panel { fill: #101d30; stroke: #2b3c55; stroke-width: 1.5; }
+      .station { fill: #173148; stroke: #42748f; stroke-width: 1.5; }
+      .execution { fill: #16283d; stroke: #3b5573; stroke-width: 1.5; }
+      .result { fill: #2b2547; stroke: #8270b7; stroke-width: 1.5; }
+      .retire { fill: #332e27; stroke: #947b54; stroke-width: 1.5; }
+      .memory { fill: #16342f; stroke: #4b8674; stroke-width: 1.5; }
+      .flow, .broadcast, .commit, .memlink { fill: none; stroke-width: 2; stroke-linejoin: round; stroke-linecap: round; }
+      .flow { stroke: #6dcee9; }
+      .broadcast { stroke: #b5a1f8; }
+      .commit { stroke: #edc37d; }
+      .memlink { stroke: #7ed8bc; }
+      .allocation { fill: #6dcee9; stroke: #101d30; stroke-width: 2; }
+      .release { fill: #edc37d; stroke: #101d30; stroke-width: 2; }
+      .badge-text { font-size: 16px; font-weight: 750; fill: #101d30; text-anchor: middle; }
+    </style>
+  </defs>
+
+  <rect width="1120" height="1440" rx="24" fill="url(#background)"/>
+  <rect x="42" y="36" width="5" height="61" rx="2.5" fill="url(#accent)"/>
+  <text x="65" y="66" font-size="34" font-weight="750">Tomasulo back-end</text>
+  <text x="65" y="96" class="body">Allocate in order · execute independently · retire precisely</text>
+  <g class="small">
+    <circle cx="743" cy="50" r="4" fill="#6dcee9"/><text x="756" y="56">Dispatch / issue</text>
+    <circle cx="743" cy="81" r="4" fill="#b5a1f8"/><text x="756" y="87">Completion</text>
+    <circle cx="937" cy="50" r="4" fill="#7ed8bc"/><text x="950" y="56">Memory</text>
+    <circle cx="937" cy="81" r="4" fill="#edc37d"/><text x="950" y="87">Retirement</text>
+  </g>
+
+  <text x="70" y="141" class="section">01 / RENAME AND ALLOCATE</text>
+  <rect x="70" y="162" width="246" height="102" rx="13" class="station"/>
+  <text x="193" y="200" class="heading center">IF · PD · ID</text>
+  <text x="193" y="232" class="body center">Up to two instructions</text>
+  <path d="M 316 213 H 356" class="flow" marker-end="url(#flow-arrow)"/>
+  <rect x="356" y="162" width="694" height="102" rx="13" class="station"/>
+  <text x="380" y="196" class="heading">Dispatch + INT / FP register alias tables</text>
+  <text x="380" y="227" class="body">2-wide rename · 8 branch checkpoints</text>
+  <text x="380" y="252" class="small">Allocates ROB and required RS / LQ / SQ entries together</text>
+  <circle cx="1024" cy="188" r="15" class="allocation"/><text x="1024" y="194" class="badge-text">A</text>
+
+  <!-- Dispatch allocates the six stations independently of ROB completion. -->
+  <path d="M 703 264 V 294 H 216 M 703 294 H 880" class="flow"/>
+  <g class="flow" marker-end="url(#flow-arrow)">
+    <path d="M 216 294 V 325"/><path d="M 536 294 V 325"/><path d="M 880 294 V 325"/>
+  </g>
+  <rect x="70" y="325" width="294" height="322" rx="17" class="panel"/>
+  <rect x="388" y="325" width="298" height="322" rx="17" class="panel"/>
+  <rect x="710" y="325" width="340" height="636" rx="17" class="panel"/>
+  <text x="90" y="357" class="section">02 / INTEGER</text>
+  <text x="408" y="357" class="section">FLOATING POINT</text>
+  <text x="730" y="357" class="section">MEMORY</text>
+
+  <g class="center">
+    <rect x="90" y="382" width="120" height="75" rx="10" class="station"/>
+    <text x="150" y="412" class="label">INT RS</text><text x="150" y="439" class="body">8 entries</text>
+    <rect x="224" y="382" width="120" height="75" rx="10" class="station"/>
+    <text x="284" y="412" class="label">MUL RS</text><text x="284" y="439" class="body">4 entries</text>
+    <rect x="408" y="382" width="78" height="75" rx="10" class="station"/>
+    <text x="447" y="412" class="label">FP</text><text x="447" y="439" class="body">6</text>
+    <rect x="498" y="382" width="78" height="75" rx="10" class="station"/>
+    <text x="537" y="412" class="label">FMUL</text><text x="537" y="439" class="body">4</text>
+    <rect x="588" y="382" width="78" height="75" rx="10" class="station"/>
+    <text x="627" y="412" class="label">FDIV</text><text x="627" y="439" class="body">2</text>
+    <rect x="730" y="382" width="300" height="75" rx="10" class="station"/>
+    <text x="880" y="412" class="label">MEM RS · 8 entries</text>
+    <text x="880" y="439" class="body">Loads · stores · atomics</text>
+  </g>
+  <g class="flow" marker-end="url(#flow-arrow)">
+    <path d="M 150 457 V 497"/><path d="M 284 457 V 497"/>
+    <path d="M 447 457 V 497"/><path d="M 537 457 V 497"/><path d="M 627 457 V 497"/>
+    <path d="M 880 457 V 497"/>
+  </g>
+  <g class="center">
+    <rect x="90" y="497" width="120" height="128" rx="10" class="execution"/>
+    <text x="150" y="530" class="label">ALU ×2</text><text x="150" y="559" class="small">Branch/JALR</text>
+    <text x="150" y="584" class="small">on pipe 0</text><text x="150" y="611" class="small">2 issue ports</text>
+    <rect x="224" y="497" width="120" height="128" rx="10" class="execution"/>
+    <text x="284" y="530" class="label">MUL / DIV</text><text x="284" y="559" class="small">Multiply</text>
+    <text x="284" y="584" class="small">Divide / rem.</text><text x="284" y="611" class="small">1 issue port</text>
+    <rect x="408" y="497" width="258" height="128" rx="10" class="execution"/>
+    <text x="537" y="528" class="label">FP execution shims</text>
+    <text x="537" y="557" class="small">FP: add / compare / convert</text>
+    <text x="537" y="583" class="small">FMUL: multiply / FMA</text>
+    <text x="537" y="609" class="small">FDIV: divide / square root</text>
+    <rect x="730" y="497" width="300" height="128" rx="10" class="memory"/>
+    <text x="880" y="529" class="label">Address generation + DMMU</text>
+    <text x="880" y="559" class="body">Sv39 DTLB · 16 entries</text>
+    <text x="880" y="586" class="small">Bypass if translation inactive</text>
+    <text x="880" y="612" class="small">Misses use shared PTW</text>
+  </g>
+
+  <!-- Arithmetic results reach the CDB without traversing the memory queues. -->
+  <g class="broadcast" marker-end="url(#result-arrow)">
+    <path d="M 150 625 V 690"/><path d="M 284 625 V 690"/><path d="M 537 625 V 690"/>
+  </g>
+  <rect x="90" y="690" width="576" height="95" rx="13" class="result"/>
+  <text x="378" y="724" class="heading center">Arithmetic completion adapters</text>
+  <text x="378" y="753" class="body center">Seven FU slots · ungranted results wait</text>
+  <text x="378" y="777" class="small center">Pipelined shims also buffer results in FIFOs</text>
+  <path d="M 378 785 V 809 H 78 V 1020" class="broadcast" marker-end="url(#result-arrow)"/>
+  <rect x="110" y="831" width="556" height="130" rx="13" class="panel"/>
+  <text x="132" y="862" class="label">Six independent reservation stations</text>
+  <text x="132" y="892" class="body">Ready operands + available FU allow issue.</text>
+  <text x="132" y="919" class="body">INT issues twice; each other RS issues once.</text>
+  <text x="132" y="946" class="body">Both CDB lanes wake waiting operands.</text>
+
+  <!-- Translation produces addresses for the preallocated LQ/SQ entries. -->
+  <path d="M 880 625 V 637 H 803 M 880 637 H 964" class="memlink"/>
+  <g class="memlink" marker-end="url(#memory-arrow)">
+    <path d="M 803 637 V 690"/><path d="M 964 637 V 690"/>
+  </g>
+  <g class="center">
+    <rect x="730" y="690" width="146" height="146" rx="11" class="memory"/>
+    <text x="803" y="725" class="label">LQ · 8</text>
+    <text x="803" y="755" class="body">+ L0 cache</text>
+    <text x="803" y="782" class="body">128 × 8 B</text>
+    <text x="803" y="811" class="small">Load / AMO / LR</text>
+    <rect x="898" y="690" width="132" height="146" rx="11" class="memory"/>
+    <text x="964" y="725" class="label">SQ · 8</text>
+    <text x="964" y="755" class="body">Store data</text>
+    <text x="964" y="782" class="body">+ addresses</text>
+    <text x="960" y="811" class="small">Commit gate</text>
+    <circle cx="857" cy="690" r="14" class="allocation"/><text x="857" y="696" class="badge-text">A</text>
+    <circle cx="1011" cy="690" r="14" class="allocation"/><text x="1011" y="696" class="badge-text">A</text>
+    <circle cx="1030" cy="819" r="14" class="release"/><text x="1030" y="825" class="badge-text">S</text>
+  </g>
+  <path d="M 940 690 V 673 H 823 V 690" class="memlink" marker-end="url(#memory-arrow)"/>
+  <text x="881" y="665" class="small center">SQ forwarding</text>
+  <g class="memlink" marker-end="url(#memory-arrow)">
+    <path d="M 803 836 V 884"/><path d="M 964 836 V 884"/>
+  </g>
+  <rect x="730" y="884" width="300" height="56" rx="10" class="memory"/>
+  <text x="880" y="907" class="label center">Data-memory router</text>
+  <text x="880" y="931" class="small center">Caches · BRAM · MMIO</text>
+
+  <!-- Memory completion is a distinct FU slot; ordinary stores bypass CDB. -->
+  <path d="M 730 800 H 698 V 987 H 730" class="broadcast" marker-end="url(#result-arrow)"/>
+  <rect x="730" y="964" width="300" height="46" rx="9" class="result"/>
+  <text x="880" y="984" class="label center">MEM completion mux</text>
+  <text x="880" y="1005" class="small center">LQ + SC result + store faults</text>
+  <path d="M 880 1010 V 1020" class="broadcast" marker-end="url(#result-arrow)"/>
+  <path d="M 1030 549 H 1073 V 1165 H 494 V 1190" class="broadcast" marker-end="url(#result-arrow)"/>
+  <text x="1054" y="1154" class="small" text-anchor="end">Ordinary successful stores: direct ROB completion</text>
+
+  <rect x="70" y="1020" width="980" height="90" rx="14" class="result"/>
+  <text x="560" y="1057" class="heading center">Common data bus · up to 2 results per cycle</text>
+  <text x="560" y="1088" class="body center">Eight FU sources · fixed-priority top-two arbiter · tags + values + exception / FP status</text>
+  <!-- The feedback bus reaches all six stations, independently of issue. -->
+  <path d="M 70 1065 H 43 V 374 H 1020" class="broadcast" stroke-dasharray="6 5"/>
+  <g class="broadcast" marker-end="url(#result-arrow)">
+    <path d="M 105 374 V 382"/><path d="M 239 374 V 382"/>
+    <path d="M 423 374 V 382"/><path d="M 513 374 V 382"/>
+    <path d="M 603 374 V 382"/><path d="M 745 374 V 382"/>
+  </g>
+  <path d="M 450 1110 V 1190" class="broadcast" marker-end="url(#result-arrow)"/>
+  <text x="340" y="1139" class="small">Mark done</text>
+
+  <text x="70" y="1180" class="section">03 / PRECISE RETIREMENT</text>
+  <rect x="70" y="1190" width="450" height="107" rx="14" class="result"/>
+  <text x="94" y="1225" class="heading">Reorder buffer · 32 entries</text>
+  <text x="94" y="1254" class="body">Tracks program order, results and faults</text>
+  <text x="94" y="1281" class="body">Head and head+1 retire when eligible</text>
+  <circle cx="495" cy="1215" r="15" class="allocation"/><text x="495" y="1221" class="badge-text">A</text>
+  <path d="M 520 1243 H 566" class="commit" marker-end="url(#commit-arrow)"/>
+  <rect x="566" y="1190" width="484" height="107" rx="14" class="retire"/>
+  <text x="590" y="1225" class="heading">Commit · up to 2 in order</text>
+  <text x="590" y="1254" class="body">INT / FP register writes · RAT clear</text>
+  <text x="590" y="1281" class="body">Release committed stores to drain</text>
+  <circle cx="1030" cy="1280" r="15" class="release"/><text x="1030" y="1286" class="badge-text">S</text>
+  <path d="M 808 1297 V 1323" class="commit" marker-end="url(#commit-arrow)"/>
+  <rect x="566" y="1323" width="484" height="66" rx="11" class="retire"/>
+  <text x="808" y="1350" class="label center">CSR / fence / trap / xRET coordination</text>
+  <text x="808" y="1377" class="small center">Serializing effects hold the ROB head</text>
+
+  <circle cx="83" cy="1339" r="14" class="allocation"/><text x="83" y="1345" class="badge-text">A</text>
+  <text x="107" y="1345" class="small">Entry allocated by dispatch</text>
+  <circle cx="83" cy="1373" r="14" class="release"/><text x="83" y="1379" class="badge-text">S</text>
+  <text x="107" y="1379" class="small">Store retirement permits SQ drain</text>
+  <text x="70" y="1420" class="small">Selected logical paths; arrows do not imply pipeline latency. Shared PTW and data router live in cpu_ooo.</text>
+</svg>

--- a/docs/diagrams/x3-board-integration.svg
+++ b/docs/diagrams/x3-board-integration.svg
@@ -1,0 +1,239 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="1632" viewBox="0 0 1200 1632" role="img" aria-labelledby="title desc">
+  <title id="title">X3 FPGA board integration</title>
+  <desc id="desc">
+    The x3_frost FPGA top contains clock generation, a common
+    xilinx_frost_subsystem and a separate ddr_subsys block design. A 300 MHz
+    differential system reference feeds IBUFDS and an MMCM; two BUFGCE_DIV
+    buffers produce the CPU clock and its divide-by-four companion. With
+    CPU_CLK_DIV equal to one these are 300 and 75 MHz. The low-BRAM JTAG-AXI
+    loader, AXI-to-BRAM controller, startup and image-reset timers, and UART
+    run at the divided clock. The FROST core, runtime memory ports and cache
+    hierarchy run at the CPU clock. BSCAN USER3 and USER4 connect the FPGA
+    TAP to the DTM; the transport crosses from JTAG TCK to the CPU-clocked
+    debug module. The core reaches uncached low BRAM and the L1I/L1D/L2
+    cache hierarchy. Its 256-bit AXI bridge joins the separate burst-capable
+    DDR JTAG-AXI master at SmartConnect. SmartConnect converts clocks and
+    widths between the CPU, divide-by-four and independent DDR UI domains.
+    A dedicated 300 MHz differential reference drives the DDR4 controller,
+    whose memory AXI interface is 512 bits. DDR calibration status mem_ok
+    crosses through a two-flop synchronizer in x3_frost before releasing the
+    common subsystem reset. The DDR transport reset depends on MMCM lock,
+    and the DDR AXI reset is derived from its UI reset. The common subsystem
+    adds startup and software-image reset holds before FROST synchronizes
+    reset into its clock domains. External DDR4 chips expose a 1 GiB mapped
+    region to the CPU at 0x80000000. Selected connections are drawn;
+    memory arrows follow requests, and responses and most clock/reset wires
+    are omitted. Boxes identify module boundaries, not clock-domain boundaries.
+  </desc>
+  <!--
+    Self-contained SVG; editable text, shapes and paths, without external assets.
+    Source map (paths relative to the repository root):
+      boards/x3/x3_frost.sv: MMCM/BUFGCE_DIV, mem_ok synchronizer, board resets,
+        common subsystem and ddr_subsys_wrapper instantiation, DDR AXI wiring.
+      boards/xilinx_frost_subsystem.sv: low-BRAM JTAG-AXI and AXI-BRAM IP,
+        16-bit startup timer, 27-bit image-load timer, BSCAN USER3/4, frost.
+      fpga/build/x3_ddr_bd.tcl: dedicated DDR reference, DDR4/SmartConnect IP,
+        three clocks, separate DDR JTAG-AXI, 256/512-bit AXI, reset/address map.
+      hw/rtl/frost.sv: reset synchronization and CPU/div4 UART CDC FIFOs.
+      hw/rtl/cpu_and_mem/cpu_and_mem.sv: BRAM, caches and debug integration.
+    The DTM/debug box groups TCK transport and CPU-domain debug logic; it
+    does not imply the DTM is entirely clocked by the CPU or divided clock.
+    Cache capacities and core details are in frost-architecture.svg.
+  -->
+  <defs>
+    <linearGradient id="background" x2="1" y2="1">
+      <stop stop-color="#101e34"/>
+      <stop offset="1" stop-color="#080f1d"/>
+    </linearGradient>
+    <linearGradient id="accent">
+      <stop stop-color="#62d8ef"/>
+      <stop offset="1" stop-color="#7f9cff"/>
+    </linearGradient>
+    <marker id="signal-arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M 1 1 L 9 5 L 1 9 Z" fill="#6dcee9"/>
+    </marker>
+    <marker id="memory-arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M 1 1 L 9 5 L 1 9 Z" fill="#7ed8bc"/>
+    </marker>
+    <marker id="control-arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M 1 1 L 9 5 L 1 9 Z" fill="#edc37d"/>
+    </marker>
+    <style>
+      text { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; fill: #edf3fc; }
+      .heading { font-size: 23px; font-weight: 650; }
+      .label { font-size: 21px; font-weight: 600; }
+      .body { font-size: 18px; fill: #bdcbde; }
+      .small { font-size: 17px; fill: #bdcbde; }
+      .section { font-size: 17px; font-weight: 650; letter-spacing: 1.4px; fill: #adbed5; }
+      .center { text-anchor: middle; }
+      .boundary { fill: #0d182a; stroke: #405673; stroke-width: 1.5; }
+      .panel { fill: #101d30; stroke: #2b3c55; stroke-width: 1.5; }
+      .signal { fill: #153149; stroke: #42748f; stroke-width: 1.5; }
+      .memory { fill: #16342f; stroke: #4b8674; stroke-width: 1.5; }
+      .control { fill: #332e27; stroke: #947b54; stroke-width: 1.5; }
+      .flow { fill: none; stroke: #6dcee9; stroke-width: 2; stroke-linejoin: round; stroke-linecap: round; }
+      .memlink { fill: none; stroke: #7ed8bc; stroke-width: 2; stroke-linejoin: round; stroke-linecap: round; }
+      .ctl { fill: none; stroke: #edc37d; stroke-width: 2; stroke-linejoin: round; stroke-linecap: round; }
+      .clock { fill: none; stroke: #edc37d; stroke-width: 2; stroke-dasharray: 6 5; stroke-linejoin: round; }
+    </style>
+  </defs>
+
+  <rect width="1200" height="1632" rx="24" fill="url(#background)"/>
+  <rect x="44" y="37" width="5" height="57" rx="2.5" fill="url(#accent)"/>
+  <text x="66" y="68" font-size="36" font-weight="750">X3</text>
+  <text x="135" y="67" font-size="29">Board integration</text>
+  <text x="67" y="95" class="body">FROST on Alveo X3522PV · clocks, memory and debug</text>
+  <g class="small">
+    <circle cx="867" cy="51" r="4" fill="#6dcee9"/>
+    <text x="880" y="57">Signal / debug</text>
+    <circle cx="867" cy="81" r="4" fill="#7ed8bc"/>
+    <text x="880" y="87">Memory</text>
+    <circle cx="1015" cy="81" r="4" fill="#edc37d"/>
+    <text x="1028" y="87">Clock / reset</text>
+  </g>
+
+  <!-- The outer boundary is FPGA RTL, excluding the external DDR4 chips. -->
+  <rect x="28" y="122" width="1144" height="1328" rx="20" class="boundary"/>
+  <text x="52" y="156" class="section">x3_frost / FPGA TOP</text>
+  <text x="1148" y="156" class="small" text-anchor="end">Module boundaries shown · selected connections</text>
+
+  <g id="clock-generation">
+    <rect x="52" y="176" width="1096" height="210" rx="14" class="panel"/>
+    <text x="76" y="208" class="section">CLOCK GENERATION</text>
+    <text x="1124" y="208" class="body" text-anchor="end">N = CPU_CLK_DIV · default N = 1</text>
+    <rect x="76" y="248" width="178" height="92" rx="12" class="signal"/>
+    <text x="165" y="278" class="label center">System ref.</text>
+    <text x="165" y="304" class="body center">300 MHz · diff.</text>
+    <text x="165" y="328" class="small center">i_sysclk_p/n</text>
+    <path d="M 254 294 H 286" class="clock" marker-end="url(#control-arrow)"/>
+    <rect x="286" y="248" width="224" height="92" rx="12" class="control"/>
+    <text x="398" y="278" class="label center">IBUFDS + MMCM</text>
+    <text x="398" y="304" class="body center">VCO 1200 MHz</text>
+    <text x="398" y="328" class="small center">output divide = 4 × N</text>
+    <path d="M 510 294 H 536 V 259 H 562" class="clock" marker-end="url(#control-arrow)"/>
+    <path d="M 536 294 V 337 H 562" class="clock" marker-end="url(#control-arrow)"/>
+    <rect x="562" y="230" width="250" height="58" rx="10" class="control"/>
+    <text x="687" y="266" class="label center">BUFGCE_DIV / 1</text>
+    <rect x="562" y="308" width="250" height="58" rx="10" class="control"/>
+    <text x="687" y="344" class="label center">BUFGCE_DIV / 4</text>
+    <path d="M 812 259 H 842" class="clock" marker-end="url(#control-arrow)"/>
+    <path d="M 812 337 H 842" class="clock" marker-end="url(#control-arrow)"/>
+    <text x="858" y="254" class="label">CPU · 300/N MHz</text>
+    <text x="858" y="280" class="body">Core, runtime memory, AXI</text>
+    <text x="858" y="332" class="label">/4 · 75/N MHz</text>
+    <text x="858" y="358" class="body">Loaders, UART, reset timers</text>
+  </g>
+
+  <!-- Common subsystem: two clock domains plus the independent JTAG TCK. -->
+  <rect x="52" y="416" width="650" height="834" rx="16" class="panel"/>
+  <text x="76" y="453" class="heading">xilinx_frost_subsystem</text>
+  <text x="76" y="481" class="body">Low-BRAM loader · BSCAN · FROST wrapper</text>
+
+  <g id="bram-loader">
+    <rect x="76" y="516" width="234" height="96" rx="12" class="signal"/>
+    <text x="193" y="546" class="label center">JTAG-AXI · /4</text>
+    <text x="193" y="572" class="body center">jtag_axi_0</text>
+    <text x="193" y="597" class="small center">Vivado debug hub · USER1</text>
+    <path d="M 310 565 H 402" class="memlink" marker-end="url(#memory-arrow)"/>
+    <text x="356" y="549" class="small center">AXI-Lite</text>
+    <rect x="402" y="516" width="276" height="96" rx="12" class="memory"/>
+    <text x="540" y="546" class="label center">AXI-to-BRAM · /4</text>
+    <text x="540" y="572" class="body center">axi_bram_ctrl_0</text>
+    <text x="540" y="597" class="small center">32-bit image writes</text>
+    <path d="M 540 612 V 656" class="ctl" marker-end="url(#control-arrow)"/>
+    <text x="527" y="640" class="small" text-anchor="end">each write</text>
+  </g>
+
+  <g id="bscan-and-reset">
+    <rect x="76" y="656" width="234" height="100" rx="12" class="signal"/>
+    <text x="193" y="687" class="label center">BSCANE2 · TCK</text>
+    <text x="193" y="714" class="body center">USER3: dtmcs</text>
+    <text x="193" y="739" class="body center">USER4: dmi · OpenOCD</text>
+    <rect x="358" y="656" width="320" height="100" rx="12" class="control"/>
+    <text x="518" y="687" class="label center">Reset timers · /4</text>
+    <text x="518" y="714" class="body center">16-bit startup · 27-bit image hold</text>
+    <text x="518" y="739" class="small center">Combined with board reset</text>
+    <path d="M 518 756 V 788" class="ctl" marker-end="url(#control-arrow)"/>
+  </g>
+
+  <!-- FROST itself spans CPU, div4 and TCK; labels describe each function. -->
+  <rect x="76" y="788" width="602" height="436" rx="14" class="boundary"/>
+  <text x="100" y="820" class="section">frost</text>
+  <text x="654" y="820" class="small" text-anchor="end">Reset synchronized into clock domains</text>
+  <path d="M 193 756 V 838" class="flow" marker-end="url(#signal-arrow)"/>
+  <path d="M 664 612 H 688 V 892 H 654" class="memlink" marker-end="url(#memory-arrow)"/>
+  <rect x="100" y="838" width="234" height="112" rx="12" class="signal"/>
+  <text x="217" y="870" class="label center">DTM + debug module</text>
+  <text x="217" y="898" class="body center">TCK ↔ CPU clock</text>
+  <text x="217" y="925" class="small center">Halt · resume · single-step</text>
+  <rect x="414" y="838" width="240" height="112" rx="12" class="memory"/>
+  <text x="534" y="870" class="label center">Low BRAM · 256 KiB</text>
+  <text x="534" y="898" class="body center">Uncached code + data</text>
+  <text x="534" y="925" class="small center">CPU ports · /4 image writes</text>
+  <path d="M 217 950 V 1002" class="flow" marker-end="url(#signal-arrow)"/>
+  <rect x="100" y="1002" width="234" height="132" rx="12" class="signal"/>
+  <text x="217" y="1036" class="label center">FROST OOO CPU</text>
+  <text x="217" y="1065" class="body center">CPU clock domain</text>
+  <text x="217" y="1093" class="body center">RV64GCB · Sv39</text>
+  <text x="217" y="1118" class="small center">UART via FIFOs</text>
+  <path d="M 334 1040 H 372 V 892 H 414" class="memlink" marker-end="url(#memory-arrow)"/>
+  <path d="M 334 1082 H 414" class="memlink" marker-end="url(#memory-arrow)"/>
+  <rect x="414" y="1002" width="240" height="132" rx="12" class="memory"/>
+  <text x="534" y="1036" class="label center">L1I + L1D → L2</text>
+  <text x="534" y="1065" class="body center">CPU clock domain</text>
+  <text x="534" y="1093" class="body center">256-bit AXI bridge</text>
+  <text x="534" y="1118" class="small center">4-bit transaction IDs</text>
+  <rect x="100" y="1160" width="554" height="42" rx="9" fill="#19273b"/>
+  <text x="377" y="1187" class="body center">UART TX / RX · /4 clock · 115200 baud · board pins</text>
+
+  <!-- DDR block design: two initiators, three clocks, two target interfaces. -->
+  <rect x="730" y="416" width="418" height="834" rx="16" class="panel"/>
+  <text x="754" y="453" class="heading">ddr_subsys</text>
+  <text x="754" y="481" class="body">Generated Vivado block design</text>
+  <rect x="754" y="516" width="370" height="96" rx="12" class="control"/>
+  <text x="939" y="547" class="label center">Dedicated DDR reference</text>
+  <text x="939" y="575" class="body center">300 MHz differential · AN27 / AN28</text>
+  <text x="939" y="598" class="small center">Independent of CPU_CLK_DIV</text>
+  <path d="M 1110 612 H 1136 V 1162 H 1124" class="clock" marker-end="url(#control-arrow)"/>
+  <rect x="754" y="656" width="370" height="100" rx="12" class="signal"/>
+  <text x="939" y="688" class="label center">DDR JTAG-AXI · /4</text>
+  <text x="939" y="716" class="body center">jtag_axi_ddr · separate master</text>
+  <text x="939" y="741" class="small center">Vivado debug hub · AXI4 burst loading</text>
+  <path d="M 939 756 V 824" class="memlink" marker-end="url(#memory-arrow)"/>
+  <text x="954" y="799" class="small">S01_AXI</text>
+  <rect x="754" y="824" width="370" height="152" rx="12" class="memory"/>
+  <text x="939" y="858" class="label center">SmartConnect · ddr_smc</text>
+  <text x="939" y="887" class="body center">Arbitration + width / clock conversion</text>
+  <text x="939" y="916" class="body center">CPU clock · /4 clock · DDR UI clock</text>
+  <text x="939" y="947" class="small center">Memory AXI + JTAG-only ECC control</text>
+  <path d="M 654 1082 H 716 V 904 H 754" class="memlink" marker-end="url(#memory-arrow)"/>
+  <path d="M 939 976 V 1108" class="memlink" marker-end="url(#memory-arrow)"/>
+  <text x="957" y="1021" class="body">512-bit memory AXI</text>
+  <text x="957" y="1048" class="small">DDR UI clock</text>
+  <rect x="754" y="1108" width="370" height="100" rx="12" class="memory"/>
+  <text x="939" y="1140" class="label center">DDR4 controller · ddr4_0</text>
+  <text x="939" y="1168" class="body center">PHY · calibration · UI clock / reset</text>
+  <text x="939" y="1194" class="small center">UI reset inverted → DDR AXI reset</text>
+
+  <!-- mem_ok is synchronized in board RTL, outside both child modules. -->
+  <path d="M 754 1162 H 716 V 1310 H 702" class="ctl" marker-end="url(#control-arrow)"/>
+  <rect x="52" y="1280" width="650" height="146" rx="14" class="control"/>
+  <text x="76" y="1313" class="label">Board reset release</text>
+  <text x="76" y="1343" class="body">DDR mem_ok → 2-flop synchronizer at CPU clock</text>
+  <text x="76" y="1372" class="body">MMCM locked &amp; mem_ok_synced → subsystem i_rst_n</text>
+  <text x="76" y="1402" class="small">The common subsystem adds startup and software-image reset holds.</text>
+  <text x="754" y="1296" class="small">DDR transport reset:</text>
+  <text x="754" y="1324" class="body">MMCM lock releases</text>
+  <text x="754" y="1350" class="body">DDR sys_reset, SmartConnect</text>
+  <text x="754" y="1376" class="body">and the DDR JTAG master.</text>
+  <path d="M 1094 1208 V 1482" class="memlink" marker-end="url(#memory-arrow)"/>
+  <text x="1078" y="1420" class="small" text-anchor="end">DDR4 pins · 72 physical bits</text>
+
+  <rect x="754" y="1482" width="370" height="88" rx="14" class="memory"/>
+  <text x="939" y="1514" class="label center">External DDR4 memory</text>
+  <text x="939" y="1544" class="body center">1 GiB mapped at CPU 0x8000_0000</text>
+  <text x="52" y="1499" class="body">FPGA TAP is shared by Vivado and OpenOCD.</text>
+  <text x="52" y="1526" class="body">DDR AXI addresses are relative to the cached region.</text>
+  <text x="52" y="1553" class="small">CPU internals and cache capacities: frost-architecture.svg</text>
+  <text x="52" y="1606" class="small">Memory arrows follow requests; responses and most clock/reset wiring are omitted. Module boxes can span clock domains.</text>
+</svg>

--- a/fpga/README.md
+++ b/fpga/README.md
@@ -11,15 +11,36 @@ Xilinx FPGA build, programming, software-loading, and debug tools.
 | `load_software/`     | Load software images into low BRAM and optional DDR without reprogramming |
 | `debug/`             | OpenOCD configurations for the RISC-V debug module (simulation and X3) |
 
-The two common flows are:
-
-```text
-RTL → build/build.py → bitstream → program_bitstream/program_bitstream.py → FPGA
-app source → make → sw.txt (+ sw_ddr.txt) → load_software/load_software.py → FPGA
+```mermaid
+flowchart LR
+    subgraph Bitstream["Build and program"]
+        direction TB
+        RTL["RTL + board setup<br/>hello_world sources"] --> Build["build/build.py<br/>compile + Vivado"]
+        Build --> Image["Bitstream<br/>initial BRAM contents"]
+        Image --> Program["program_bitstream.py<br/>configure FPGA"]
+    end
+    subgraph Reload["Reload software"]
+        direction TB
+        App["Application source"] --> Loader["load_software.py<br/>build for board + clock"]
+        Loader --> DDR["Hold CPU in reset<br/>load DDR if present"]
+        DDR --> BRAM["Load low BRAM"]
+        BRAM --> Run["Reset counter expires<br/>CPU starts program"]
+    end
+    Bitstream -.-> Reload
 ```
 
-The loader data path is JTAG-AXI → AXI-to-BRAM → low BRAM → CPU. DDR images
-go through the board's separate burst-capable JTAG-AXI master.
+`build/build.py` compiles `hello_world` for the initial BRAM image before
+synthesis. Software reload uses `load_software/load_software.py`, which
+rebuilds the selected app by default and loads `sw.txt` plus any
+`sw_ddr.txt`; `--skip-build` reuses eligible existing artifacts.
+
+BRAM writes use JTAG-AXI through the AXI-to-BRAM controller. DDR images use
+the board's separate burst-capable JTAG-AXI master. When a DDR image is
+present, the loader first writes one BRAM word to assert CPU reset, loads
+DDR while periodically re-arming that reset, then writes the full BRAM
+image. The CPU starts after the image-load reset counter expires. See the
+[board integration diagram](../docs/diagrams/x3-board-integration.svg) for
+the two loading paths and reset dependencies.
 
 The RISC-V debug module (Phase 3 M3) shares the FPGA's own TAP through two
 BSCAN USER chains (see `../boards/README.md`); `debug/` holds the OpenOCD

--- a/hw/rtl/README.md
+++ b/hw/rtl/README.md
@@ -1,8 +1,8 @@
 # FROST RTL
 
 FROST's synthesizable SystemVerilog: an out-of-order RV64GCB CPU with a
-2-wide IF/PD/ID front-end, Tomasulo scheduling across six function units, and
-precise 2-wide in-order commit. The core takes M/S/U-mode traps with delegation
+2-wide IF/PD/ID front-end, Tomasulo scheduling across six reservation stations,
+and precise 2-wide in-order commit. The core takes M/S/U-mode traps with delegation
 (Phase 3), translates through Sv39 (an 8-entry ITLB in IF, a 16-entry DTLB on
 the data side, and one read-only page-table walker shared by both), and has
 separate instruction and data memory ports. It is RV64-only
@@ -26,27 +26,18 @@ lives under `fpga/` and `boards/`.
 
 ## Top-Level Shape
 
-```
-frost.sv
-  cpu_and_mem.sv
-    instruction RAM  <---- JTAG/software-load port on clk_div4
-    data RAM (low 256 KiB BRAM, 1-cycle)
-    fetch_provider -> two-line L1I fetch buffer (cached fetch @ 0x8000_0000)
-    cached tier @ 0x8000_0000 (1 GiB), frost_cache_hierarchy:
-      data: cached_tier_adapter -> L1D (128 KiB BRAM) -----------------------\
-      walker: PTW -----------------------------------------\                 arbiter ->
-      instr: L1I (16 KiB BRAM, read-only) ------------------ arbiter -------/
-        [L2 (2 MiB URAM data + packed tags, X3)] -> line_port_axi_bridge -> DDR AXI port
-           (behavioral DDR model in sim; board DDR controller on hardware)
-    MMIO timer/UART/FIFOs
-    debug/: JTAG TAP -> DTM -> debug module -> slice writer (programming port)
-    cpu_ooo.sv
-      IF -> PD -> ID -> 2-wide dispatch
-                         ROB / RAT / RS / LQ / SQ / CDBx2
-                         FU shims around ALU, MUL/DIV, FPU
-                         2-wide commit -> INT/FP regfiles
-  UART clock-domain crossing FIFOs
-```
+The shared [CPU and system architecture diagram](../../docs/diagrams/frost-architecture.svg)
+shows the datapath, translation, memory tiers, MMIO and debug interfaces.
+The [cache diagram](../../docs/diagrams/cache-hierarchy.svg) expands the tagged
+arbiter tree and its X3 L2 configuration.
+
+`frost.sv` wraps `cpu_and_mem.sv` and the UART clock-domain crossing FIFOs.
+`cpu_and_mem` integrates the low BRAM, fetch provider, cached-tier adapter,
+cache hierarchy, AXI bridge, MMIO and debug module. It instantiates
+`cpu_ooo.sv`, which owns IF/PD/ID, dispatch, `tomasulo_wrapper`, the CSR and
+trap units, and the shared page-table walker. The walker reaches the cache
+hierarchy through its own line port. The bridge connects to a behavioral
+DDR model in simulation or the board DDR controller on hardware.
 
 The front-end stages are IF, PD, and ID:
 
@@ -213,8 +204,8 @@ backend notes.
 ## Memory Map
 
 The low BRAM memory is 256 KiB (95 KiB ROM + the 1 KiB debug slice + 160 KiB
-RAM in the unified linker script); the data port additionally reaches a
-1 GiB cached region served by the cache hierarchy:
+RAM in the unified linker script). Both instruction fetch and data accesses
+also reach a 1 GiB cached region served by the cache hierarchy:
 
 | Region | Address | Size | Description |
 |--------|---------|------|-------------|

--- a/hw/rtl/cpu_and_mem/cpu/README.md
+++ b/hw/rtl/cpu_and_mem/cpu/README.md
@@ -4,10 +4,11 @@
 predictor, RAS, RVC) with the [`tomasulo/`](tomasulo/README.md) out-of-order
 back-end. Shared functional units under `ex_stage/` connect through OOO shims.
 
-```
-   IF → PD → ID → 2-wide dispatch → tomasulo_wrapper → commit → regfiles
-                                     (ROB / RAT / RS×6 / LQ+L0$ / SQ / CDB×2)
-```
+See the shared [CPU and system architecture diagram](../../../../docs/diagrams/frost-architecture.svg)
+for the front-end, Sv39 translation, memory interfaces and in-order commit.
+The [Tomasulo back-end diagram](../../../../docs/diagrams/tomasulo-backend.svg)
+expands register renaming, independent execution paths, result broadcast and
+load/store ordering.
 
 ## What lives in cpu_ooo.sv
 

--- a/hw/rtl/cpu_and_mem/cpu/tomasulo/README.md
+++ b/hw/rtl/cpu_and_mem/cpu/tomasulo/README.md
@@ -5,35 +5,18 @@ out-of-order completion, and precise in-order commit for RV64IMACBFD + Zbkb +
 Zicond + Zicntr + Zifencei + Zihintpause. Dispatch, RAT, ROB, CDB, and commit
 are two-wide. Most reservation stations issue once per cycle; INT_RS issues
 twice to two ALUs, with branches restricted to pipe 0. Up to six stations may
-issue in one cycle, seven operations counting INT_RS's second port. Aligned
-stores bypass the two-lane CDB. Both CDB lanes can wake an RS entry in the same
-cycle; `LANE1_ISSUE_BYPASS` controls the lane-1 bypass per RS instance.
+issue in one cycle, seven operations counting INT_RS's second port. Ordinary
+successful stores bypass the two-lane CDB. Both CDB lanes can wake an RS entry
+in the same cycle; `LANE1_ISSUE_BYPASS` controls the lane-1 bypass per RS instance.
 
-```
-   IF → PD → ID → dispatch        ─► ROB          ┌─► commit ─► regfile / SQ /
-                  rename/resource     (32 entries)│             trap entry / redirect
-                  allocation         + RAT (INT+FP,
-                                      8 ckpts)
-                                  │
-                                  ▼
-                         ┌────────────────────────┐
-                         │   6 reservation        │
-                         │   stations             │
-                         │   INT / MUL / MEM /    │
-                         │   FP / FMUL / FDIV     │
-                         └─────────┬──────────────┘
-                                   │ wake on CDB,
-                                   │ issue when ready
-                                   ▼
-                         FU shims (ALU, MUL/DIV, FP*)
-                                   │
-                         LQ + L0 cache, SQ
-                                   │
-                                   ▼
-                              CDB (2 lanes)
-                          ─ broadcast values & tags
-                          ─ wakes RS, marks ROB done
-```
+![FROST Tomasulo back-end showing parallel allocation, independent arithmetic and translated-memory execution, two-lane completion, and precise retirement](../../../../../docs/diagrams/tomasulo-backend.svg)
+
+Dispatch allocates tracking entries before issue. Arithmetic completions reach
+the CDB through their own adapters; the memory branch separately translates
+addresses and uses the LQ/SQ. Successful ordinary stores complete the ROB
+directly, while loads, atomic results, and store faults use the MEM CDB slot.
+The diagram shows selected logical paths rather than pipeline timing; matching
+`A` and `S` badges identify allocation and store-retirement connections.
 
 ## Directory contents
 
@@ -95,10 +78,10 @@ front-end redirects and the RAT restores in the same cycle, then the
 OOO back-end's partial flush fires one cycle later. This cuts the
 typical penalty from ~15 cycles to ~2.
 
-JALR mispredictions and exceptions go through the slower commit-time
-path because their recovery PC depends on results that may still be
-in flight when the fast path would fire. Both paths use the same
-age-based partial flush primitive everywhere downstream.
+JALR mispredictions use the commit-time recovery path. Like early conditional
+branch recovery, they use an age-based partial flush to discard younger work.
+Exceptions instead enter the trap machinery at commit and cause a full flush;
+trap entry also applies the privilege and delegation rules.
 
 ### Serializing instructions
 
@@ -108,8 +91,8 @@ A small FSM in the ROB pins most of these instructions at the commit head
 | Class               | Behavior |
 |---------------------|----------|
 | WFI                 | Stalls at head until an interrupt is pending. |
-| CSR                 | Read result rides the CDB; the side effect is applied at commit via a `csr_file` handshake. A conservatively classified translation CSR then enters `SERIAL_CSR_TRANSLATION_DRAIN`, retains the completed handshake, and waits for committed stores to drain and for the retirement permit before retiring. Ordinary CSRs keep their original completion/retire cycle. |
-| FENCE / FENCE.I     | Drains the SQ before commit. FENCE.I then enters a cache-sync state (`SERIAL_FENCE_I_SYNC`): it asserts the cache-sync request and holds the head until both the hierarchy reports done (L1D writeback-all, then L1I invalidate-all) and retirement is permitted. Its serializer-owned event produces the pipeline + fetch-buffer flush so the front-end refills from post-writeback memory. |
+| CSR                 | The read result rides the CDB. At the commit head, a `csr_file` execution handshake computes the architectural update. A conservatively classified translation CSR then enters `SERIAL_CSR_TRANSLATION_DRAIN`, retains the completed handshake, and waits for committed stores to drain and for the retirement permit before retiring and applying the architectural write. Ordinary CSRs keep their original completion/retire cycle. |
+| FENCE / FENCE.I / SFENCE.VMA | Drains committed SQ entries before commit. FENCE.I and SFENCE.VMA then enter `SERIAL_FENCE_I_SYNC`: the cache-sync request holds the head until both the hierarchy reports done (L1D writeback-all, then L1I invalidate-all) and retirement is permitted. SFENCE.VMA also opens the TLB/PTW invalidation window. The serializer-owned event produces the pipeline + fetch-buffer flush so the front-end refills from post-writeback memory. |
 | MRET                | Handshakes with `trap_unit`; redirect PC = `mepc`. SRET and DRET ride the same machinery with `sepc` and `dpc`. |
 | AMO / LR / SC       | Head-ordered atomics; the ROB FSM does not stall them. AMO and SC fire only at the ROB head with the SQ committed-empty (no older stores in flight): the AMO gate is at LQ issue, the SC gate at the wrapper's reservation check. LR fires at the head. While an AMO owns the head, interrupt delivery is shielded (`trap_unit.i_amo_at_head`, fed by the ROB's `o_head_is_amo`). A trap flush anywhere in the AMO's [write-launch, commit] window would orphan its in-flight memory write: memory mutated by a squashed instruction that then re-executes, a double-applied atomic. The pending interrupt is therefore held until the AMO commits. Exceptions stay ungated, since a faulting AMO never issues its memory ops. Device (MMIO) loads carry the mirror-image shield on the read side (`trap_unit.i_device_read_at_head`, fed from the router's `o_device_request_pending`): their terminal accept pops a destructive device register, so interrupt delivery is held from before the accept until the load commits, and the router refuses to arm until that hold is established. |
 
@@ -237,7 +220,7 @@ snapshot overlays slot 1's rename.
 
 The ROB retires up to two instructions per cycle. Head and head+1 commit
 together when both are done, neither is a serializing instruction (CSR,
-FENCE, FENCE.I, WFI, MRET, AMO, LR, SC), neither is an exception, the head is
+FENCE, FENCE.I, SFENCE.VMA, WFI, xRET, AMO, LR, SC), neither is an exception, the head is
 not mispredicting, and head+1 is not a mispredicted or early-recovered
 branch. A correctly predicted branch may retire at head+1; it uses a second
 checkpoint-free RAT port and held BTB/bimodal training captures. The INT and
@@ -253,8 +236,9 @@ Two bypass paths shorten commit and completion latency.
 CDB to head-done bypass: when either CDB lane targets the ROB head or head+1,
 the value flows into the commit mux in the same cycle instead of waiting for
 the `rob_done[head]` flop to update. This cuts one cycle off the common
-ordinary-completion path. Exceptions, branches, CSR, FENCE, FENCE.I, WFI, and
-MRET are excluded and still use the commit-time serial path.
+ordinary-completion path. Exceptions, branches, CSR, FENCE, FENCE.I,
+SFENCE.VMA, WFI, and xRET are excluded and still use the serial, branch-update,
+or trap paths.
 
 LQ address-update and completion bypasses: MEM_RS issues a pre-issue
 look-ahead one cycle early so the LQ's address-update CAM match is registered

--- a/hw/rtl/cpu_and_mem/cpu/tomasulo/cdb_arbiter/README.md
+++ b/hw/rtl/cpu_and_mem/cpu/tomasulo/cdb_arbiter/README.md
@@ -3,12 +3,29 @@
 A combinational fixed-priority arbiter selecting up to two of eight FU
 completions per cycle for the two CDB lanes.
 
-One balanced merge tree computes both winners together. The leaves are four
-contiguous priority pairs:
+One balanced merge tree computes both winners together. Its first stage
+merges four contiguous priority pairs; every merge keeps up to two results:
 
+```mermaid
+flowchart TB
+    PM["MUL / MEM pair"] --> HIGH["Higher four: top two"]
+    PA["ALU / ALU2 pair"] --> HIGH
+    PD["DIV / FP_DIV pair"] --> LOW["Lower four: top two"]
+    PF["FP_MUL / FP_ADD pair"] --> LOW
+    HIGH --> ROOT["Root: top two winners"]
+    LOW --> ROOT
+    ROOT --> R0["Lane 0 value restore"]
+    ROOT --> R1["Lane 1 value restore"]
+    LIVE["Live ALU and ALU2 values"] -.-> R0
+    LIVE -.-> R1
+    R0 --> C0["CDB lane 0"]
+    R1 --> C1["CDB lane 1"]
 ```
-[MUL, MEM]  [ALU, ALU2]  [DIV, FP_DIV]  [FP_MUL, FP_ADD]
-```
+
+Solid arrows carry selected packets; dashed arrows bypass the payload tree
+with live ALU values. Both lanes use the root's source selects for value
+restoration. Full-flush kill suppresses broadcast validity and grants; it
+does not change the selected payloads.
 
 Each node carries the highest two valid packets and their one-hot source IDs.
 Each merge concatenates the higher-priority list before the lower and keeps its

--- a/hw/rtl/cpu_and_mem/cpu/tomasulo/reorder_buffer/README.md
+++ b/hw/rtl/cpu_and_mem/cpu/tomasulo/reorder_buffer/README.md
@@ -82,19 +82,42 @@ flushing, and slot 2 implies slot 1 and is never presented while
 [`rob_serializer.sv`](rob_serializer.sv) holds the commit head when an entry
 needs external coordination:
 
-```
-SERIAL_IDLE ──► WAIT_SQ                   (FENCE / FENCE.I SQ drain)
-            ├─► FENCE_I_SYNC              (FENCE.I cache sync)
-            ├─► CSR_EXEC ──► CSR_TRANSLATION_DRAIN
-            │                 (translation-class CSR committed-SQ drain)
-            ├─► MRET_EXEC                 (xRET handshake with trap_unit)
-            ├─► WFI_WAIT                  (stall until interrupt pending)
-            └─► TRAP_WAIT                 (stall until trap_unit takes the trap)
+```mermaid
+stateDiagram-v2
+    direction LR
+    [*] --> IDLE
+    IDLE --> WAIT_SQ: fence, SQ busy
+    IDLE --> FENCE_I_SYNC: sync fence, SQ empty
+    WAIT_SQ --> FENCE_I_SYNC: sync fence, SQ empty
+    WAIT_SQ --> IDLE: FENCE, SQ empty
+    FENCE_I_SYNC --> IDLE: sync done, permit
+    IDLE --> CSR_EXEC: CSR
+    CSR_EXEC --> CSR_TRANSLATION_DRAIN: done, translation CSR
+    CSR_EXEC --> IDLE: done, ordinary CSR
+    CSR_TRANSLATION_DRAIN --> IDLE: SQ empty, permit
+    IDLE --> MRET_EXEC: xRET
+    MRET_EXEC --> IDLE: xRET done
+    IDLE --> WFI_WAIT: WFI, no interrupt
+    WFI_WAIT --> IDLE: interrupt pending
+    IDLE --> TRAP_WAIT: exception
+    TRAP_WAIT --> IDLE: trap taken
 ```
 
-WAIT_SQ falls through to IDLE for a plain FENCE once the committed SQ
-entries drain. FENCE.I instead advances into FENCE_I_SYNC, or enters it
-directly from IDLE if the SQ is already committed-empty.
+State names omit the RTL's `SERIAL_` prefix. In the labels, `SQ empty` means
+**committed** SQ entries have drained, `sync fence` means FENCE.I or
+SFENCE.VMA, `permit` is the normal retirement permit, and `xRET` includes
+MRET, SRET, and DRET. Commas join conditions that must both hold.
+
+Leaving IDLE requires a ready
+head and no commit hold, early recovery, or flush; exception handling has
+priority over the instruction class. Each state holds while its transition
+condition is false. Reset or a full flush returns any state to IDLE.
+
+The fence class here includes FENCE, FENCE.I, and SFENCE.VMA. WAIT_SQ falls
+through to IDLE for a plain FENCE once the committed SQ entries drain.
+FENCE.I and SFENCE.VMA instead advance into FENCE_I_SYNC, or enter it directly
+from IDLE if the SQ is already committed-empty. A plain FENCE with a drained
+SQ, or WFI with an interrupt already pending, can retire without leaving IDLE.
 
 Each owned state asserts `commit_stall` until its release condition is met.
 An ordinary CSR drops the stall on `i_csr_done` and retires on its historical
@@ -134,10 +157,12 @@ That level rises and falls on exactly the same edges as the sync request for an
 SFENCE.VMA, stays low for a plain FENCE.I, and keeps the live ROB-head read out
 of the TLB/PTW invalidation cone.
 
-AMO / LR / SC have no serial state of their own: their store ordering
-is enforced at LQ issue time (the load waits for the ROB head plus a
-committed-empty SQ), so once the CDB marks the entry done it commits
-through the ordinary path.
+AMO / LR / SC have no serial state of their own. LQ issue requires LR to be
+at the ROB head, and AMO additionally waits for a committed-empty SQ. SC
+resolves through the wrapper's `sc_pending_unit`, which requires the ROB
+head and a committed-empty SQ before checking the reservation and producing
+its result. Once the CDB marks an atomic entry done, it commits through the
+ordinary completion path.
 
 When the head exception fires, the ROB exports the head entry's value
 slot as `o_trap_value` alongside `o_trap_pc` / `o_trap_cause`. For a
@@ -151,7 +176,7 @@ The ROB retires up to two entries per cycle. When head and head+1 are
 both done and both pass a hazard gate, both entries retire in the
 same cycle. The hazard gate excludes anything that has to be the
 last thing to happen before its commit-time side effect: CSRs,
-FENCE / FENCE.I, WFI, MRET, AMO / LR / SC, exceptions, and any
+FENCE / FENCE.I / SFENCE.VMA, WFI, xRET, AMO / LR / SC, exceptions, and any
 mispredicting head or head+1 branch. That leaves the common case of
 two ordinary-completion entries retiring back-to-back.
 
@@ -189,7 +214,7 @@ the parallel CDB write ports. Each lane writes exception state and cause only
 when its completion is exceptional; a non-exception completion preserves any
 allocation-time legality fault.
 
-Exceptions, branch / JAL / JALR, CSR, FENCE / FENCE.I, WFI, and MRET fall
+Exceptions, branch / JAL / JALR, CSR, FENCE / FENCE.I / SFENCE.VMA, WFI, and xRET fall
 through to the existing serial / branch-update / trap
 paths; the bypass applies only to ordinary completions.
 
@@ -221,7 +246,7 @@ The exceptions:
   and the target is known at decode, so there is nothing to wait for.
 - JALR has its link address written at allocation but waits for
   `branch_jump_unit` to resolve the target.
-- WFI, FENCE, FENCE.I, and MRET are marked done immediately. They have
+- WFI, FENCE, FENCE.I, SFENCE.VMA, and xRET are marked done immediately. They have
   no execution phase, only a commit-time effect handled by the
   serializing FSM.
 

--- a/hw/rtl/lib/cache/README.md
+++ b/hw/rtl/lib/cache/README.md
@@ -94,16 +94,11 @@ The full-system integration fixes `HAS_L2=1`, matching X3. `HAS_L2=0` remains
 available at the lower-level `frost_cache_hierarchy` boundary for focused unit
 coverage and future reuse; it is not a supported board shape.
 
-```
-L1-only (HAS_L2=0):  adapter -> L1D (BRAM) ----------\
-                     walker ------------\             arbiter -> bridge -> external memory
-                                         arbiter ----/
-                     fetch   -> L1I (BRAM) ---------/
-X3      (HAS_L2=1):  adapter -> L1D (BRAM) ----------\
-                     walker ------------\             arbiter -> L2 (URAM data + tags) -> bridge -> DDR4
-                                         arbiter ----/
-                     fetch   -> L1I (BRAM) ---------/
-```
+[![FROST cache hierarchy: L1D, walker and L1I arbitration into L2 and DDR, with the L1-only unit configuration below](../../../../docs/diagrams/cache-hierarchy.svg)](../../../../docs/diagrams/cache-hierarchy.svg)
+
+The main view shows X3 capacities and the two arbiter instances separately.
+The lower view shows the L2 bypass exercised by unit benches. Arrows follow
+requests; responses return using the transaction ID prefixes described below.
 
 The arbiter tree is two 2:1 `line_port_arbiter` instances. Both are pure
 combinational pass-throughs, so the pair behaves exactly like a 3:1
@@ -133,10 +128,12 @@ downstream width the two-port shape used: the L1D keeps `{1'b0, UP_ID_BITS-bit
 local id}`, the walker gets `{2'b10, local id}` and the L1I `{2'b11, local
 id}` with `UP_ID_BITS - 1`-bit local ids. Nothing below the top arbiter
 changes: the L2 (or the bridge on the L1-only shape) sees the same id width,
-within the 4-bit AXI id space the block designs already provide. The narrower
-prefix caps the L1I at 2 miss slots and the walker at 2 concurrent walks. The
-L1I loses nothing, since its master, the two-line fetch provider, never has
-more than 2 requests in flight.
+within the 4-bit AXI id space the block designs already provide. With the
+default `UP_ID_BITS=3`, the two-bit port prefix leaves each of those ports a
+2-bit local ID field. L1I reserves one bit to distinguish fills from
+writebacks, leaving 2 miss slots. The walker
+keeps one walk in flight and uses ID zero. The L1I loses nothing, since its
+master, the two-line fetch provider, never has more than 2 requests in flight.
 
 A walk is a short chain of dependent 8-byte PTE reads, one per level, each a
 full-line read on this port; the walker extracts its PTE from the 256-bit
@@ -144,9 +141,9 @@ response the way `cached_tier_adapter` extracts a beat. One walker serves both
 TLBs behind a requester mux in `cpu_ooo`: the data side wins, and a registered
 owner bit steers each response to the TLB that asked. One walk is in flight at
 a time, so the port never carries more than one read at once; the 2-bit local
-id budget is headroom. Walks are read-only: the A/D bits trap instead of
-updating in hardware (Svade), so there is no PTE-write path anywhere in the
-fabric.
+id budget is headroom. Walks are read-only: the walker does not update PTE
+A/D bits in hardware. Accesses that need those bits set instead take page
+faults (Svade), so the walker has no PTE-write path.
 
 PTEs live in cacheable memory and a walk reads through the L2 when present or
 directly through the bridge in the L1-only shape, not through the L1D, so a

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,33 +1,46 @@
 # Frost Test Infrastructure
 
 Runners for RTL simulation, architecture compliance, ISA regression, random
-instruction torture, Yosys synthesis, and formal verification.
+instruction torture, synthesis, formal verification, and Python tooling checks.
 
 ## Overview
 
+```mermaid
+flowchart LR
+    wrapper["scripts/frost.py"]
+    subgraph image["frost Docker image"]
+        subgraph simulation["RTL simulation"]
+            registry["test_run_cocotb.py<br/>CPU / SoC TEST_REGISTRY"]
+            isa["Architecture compliance<br/>riscv-tests and torture"]
+            ethernet["net10g/run.py<br/>Standalone Ethernet targets"]
+            verilator["Verilator + cocotb"]
+            registry --> verilator
+            isa --> verilator
+            ethernet --> verilator
+        end
+        subgraph synthesis["Synthesis"]
+            synth["test_run_yosys.py<br/>net10g/synthesize.py"] --> yosys["Yosys"]
+        end
+        subgraph formal["Formal verification"]
+            proofs["test_run_formal.py<br/>formal/*.sby"] --> sby["SymbiYosys<br/>Yosys + proof engines"]
+        end
+        python["Fast Python tests<br/>pytest: helpers and tooling"]
+    end
+    wrapper --> simulation
+    wrapper --> synthesis
+    wrapper --> formal
+    wrapper --> python
 ```
-┌─────────────────────────────────────────────────────────────────────────────────────────────────┐
-│                                Test Infrastructure                                              │
-├─────────────────────────────────────────────────────────────────────────────────────────────────┤
-│                                                                                                 │
-│  ┌────────────────┐ ┌────────────────┐ ┌────────────────┐ ┌────────────────┐ ┌────────────────┐ │
-│  │test_run_cocotb │ │test_arch_comp- │ │test_riscv_     │ │test_riscv_     │ │test_run_yosys  │ │
-│  │          .py   │ │  liance.py     │ │    tests.py    │ │  torture.py    │ │          .py   │ │
-│  │ RTL Simulation │ │ Arch Compli-   │ │ ISA Pipeline   │ │ Random Instr   │ │ Synthesis      │ │
-│  │ • CPU unit     │ │   ance         │ │ • riscv-tests  │ │ • 20-test      │ │ • Yosys        │ │
-│  │   tests        │ │ • riscv-arch-  │ │ • rv64 ISA     │ │   corpus       │ │   synthesis    │ │
-│  │ • Real C progs │ │   test         │ │   suites       │ │ • IMAFDC       │ │ • No vendor    │ │
-│  │ • Verification │ │ • rv64i_m      │ │ • Benchmarks   │ │ • Spike refs   │ │   IPs          │ │
-│  └───────┬────────┘ └───────┬────────┘ └───────┬────────┘ └───────┬────────┘ └───────┬────────┘ │
-│          │                  │                  │                  │                  │          │
-│          v                  v                  v                  v                  v          │
-│  ┌──────────────────────────────────────────────────────────────────────┐  ┌────────────────┐   │
-│  │                            Simulator                                 │  │     Yosys      │   │
-│  │                                Verilator                             │  │ (open-source)  │   │
-│  └──────────────────────────────────────────────────────────────────────┘  └────────────────┘   │
-│                                                                                                 │
-└─────────────────────────────────────────────────────────────────────────────────────────────────┘
-```
+
+The CPU/SoC registry covers block benches, directed tests, and compiled
+applications. The [standalone Ethernet benches](net10g/README.md) have their
+own target registry and synthesis runner. Formal targets use the engines
+selected by each `.sby` file; see the [formal guide](../formal/README.md).
+
+Simulation coverage spans low BRAM and cached DDR. Architecture compliance
+also has an instruction-cache-only tier; riscv-tests and torture provide
+Sv39 execution modes. The runner sections below describe which combinations
+each suite supports.
 
 ## Reproducible Local Execution
 
@@ -49,8 +62,8 @@ ownership scan skips `.git/` and `hw/`.
 
 ### `test_run_cocotb.py`
 
-Runs Cocotb simulations directly or through pytest. `TEST_REGISTRY` in
-`test_run_cocotb.py` is the canonical list of targets:
+Runs CPU/SoC Cocotb simulations directly or through pytest. `TEST_REGISTRY` in
+`test_run_cocotb.py` is the canonical list of those targets:
 
 ```bash
 ./scripts/frost.py cocotb --list-tests
@@ -133,9 +146,11 @@ resolution priority, Sv39 permissions and physical-address composition,
 PMA faults and MMIO, two-cycle hit latency and one-result-per-cycle throughput,
 miss skid handling, and recovery with ROB-tag reuse.
 
-Real-program tests default to the whole-program low-BRAM tier (`bram`).
-`FROST_COCOTB_MEM_CONFIG=ddr` relinks each app into cached DDR, which
-exercises the L1I and the D-side cached tier:
+Real-program tests default to the `bram` tier, which normally places code and
+data in low BRAM. `FROST_COCOTB_MEM_CONFIG=ddr` selects cached-DDR linking to
+exercise the L1I and the D-side cached tier. Some apps override this choice:
+the AMO and timer torture apps always use DDR, CoreMark-PRO has a DDR-backed
+heap, and OpenSBI smoke uses a fixed BRAM-shim/DDR-firmware layout.
 
 ```bash
 FROST_COCOTB_MEM_CONFIG=ddr ./scripts/frost.py cocotb hello_world
@@ -158,9 +173,11 @@ with a golden reference generated by the image's pinned Spike
 (`sw/apps/arch_test/generate_references.py`). References live under
 `sw/apps/arch_test/references/rv64i_m/`.
 
-Supported extensions: I, M, A, F, D, C, B, K, Zicond, Zifencei, privilege,
-D_Zcd, hints (262 tests). There is no F_Zcf: RV64C reinterprets the
-C.FLW/C.FSW slots as C.LD/C.SD, so Zcf is rv32-only.
+Suite groups: I, M, A, F, D, C, B, K, Zicond, Zifencei, privilege, D_Zcd,
+and hints. `EXTENSION_TEST_FILTERS` and `EXTENSION_TEST_EXCLUDES` restrict
+these groups to implemented instructions; for example, K covers Frost's Zbkb
+subset. There is no F_Zcf: RV64C reinterprets the C.FLW/C.FSW slots as
+C.LD/C.SD, so Zcf is rv32-only.
 
 Run `./scripts/frost.py run make -C tests clean` before each of the runner
 invocations below.
@@ -176,7 +193,7 @@ invocations below.
 ./scripts/frost.py run python3 tests/test_arch_compliance.py \
   --test rv64i_m/I/src/addw-01.S
 
-# Include tests too large for simulation (hardware validation)
+# Include large cases normally filtered out of Verilator runs
 ./scripts/frost.py run python3 tests/test_arch_compliance.py --all --no-sim-filter
 
 # Select the memory tier the test runs from (default: ddr)
@@ -217,8 +234,8 @@ The runner is Verilator only.
 
 Tests with more than 5000 test cases (`SIM_MAX_TEST_CASES`) are filtered out
 by default because they take too long under Verilator; `--no-sim-filter`
-includes them for hardware validation runs. At the current suite snapshot no
-rv64i_m test exceeds the limit.
+includes them in the same simulation runner. Hardware regression uses the
+native [FPGA workflow](../fpga/README.md).
 
 In CI, the suite runs as a GitHub Actions matrix of extension x memory tier
 (`[bram, ddr]`) with `fail-fast: false` (`Arch Tests`). Zifencei (fence.i and
@@ -415,7 +432,8 @@ it supports. Most targets declare `bmc` and `cover`. `rs_issue2_selector` and
 `fu_cdb_adapter_payload_no_refill` are BMC-only. `branch_prediction_alias`
 also uses BMC only, with depth 1 exhausting its state-free public alias cone.
 `prediction_release` and
-`prediction_metadata_tracker` also declare `prove` (induction); `tlb` adds
+`prediction_metadata_tracker` also declare `prove` (unbounded proofs via
+ABC PDR); `tlb` adds
 `bmc_itlb` and `cover_itlb`, and `tomasulo_wrapper` adds `fmul_repair_bmc`.
 
 ```bash
@@ -545,7 +563,9 @@ job runs the default/unmarked tests as the host UID and GID with `HOME=/tmp`,
 which also guards the non-root execution model used by `scripts/frost.py`.
 
 The riscv-tests, torture, and Cocotb real-program suites run separate `bram`
-(whole program in low BRAM) and `ddr` (whole program in cached DDR) jobs.
+and `ddr` jobs. These select low-BRAM and cached-DDR linking for apps that
+honor `MEM_CONFIG`; dedicated DDR apps and fixed boot layouts keep their own
+placement, as described above.
 Architecture compliance uses both tiers for most extensions; F/D DDR is
 disabled because it times out on GitHub-hosted runners:
 
@@ -556,9 +576,9 @@ disabled because it times out on GitHub-hosted runners:
   tests with matching custom Verilator settings so they reuse compilation.
   Each CoreMark-PRO workload (`core`, `cjpeg`, `linear_alg`, `loops`, `nnet`,
   `parser`, `radix2`, `sha`, and `zip`) also gets its own job in each tier.
-  Two additional `bram` jobs cover the DDR probes/fetch-fuzz variants (which
-  already exercise DDR or use a separate fetch-fuzz build) and the
-  tier-independent unit benches. This gives 19 BRAM jobs and 17 DDR jobs. Each job uses
+  Additional `bram` jobs cover the DDR probes/fetch-fuzz variants (which
+  already exercise DDR or use a separate fetch-fuzz build), fixed-layout
+  OpenSBI smoke, and the tier-independent unit benches. Each job uses
   `scripts/frost.py pytest` to clean before running in the shared pinned
   image as the runner UID/GID, with `FROST_COCOTB_MEM_CONFIG` selecting the
   tier. Pytest prints all test durations to help rebalance the shards.
@@ -567,8 +587,9 @@ disabled because it times out on GitHub-hosted runners:
   `bram` tier and F/D from the `ddr` tier, as described above; there is no
   F_Zcf batch. The matrix is separate from the Cocotb jobs so long-running FP
   tests do not block them.
-- riscv-tests: a suite x memory tier matrix over the twelve rv64 suites, plus
-  a benchmark x memory tier matrix.
+- riscv-tests: a suite x memory tier matrix in the physical (`p`)
+  environment, plus the user-level suites in DDR's Sv39 virtual (`v`)
+  environment and a benchmark x memory tier matrix.
 - riscv-torture: a memory tier (`[bram, ddr]`) matrix plus `ddr` paged.
 - Fast Python tests: default/unmarked tests, selected by excluding the
   `cocotb`, `synthesis`, `formal`, and `slow` markers; run non-root in the

--- a/verif/README.md
+++ b/verif/README.md
@@ -7,38 +7,46 @@ software reference models.
 
 ### Verification Data Flow
 
-```
-┌─────────────────────────────────────────────────────────────────┐
-│                       TEST ORCHESTRATION                        │
-│  ┌──────────────────┐    ┌──────────────────┐                   │
-│  │ InstructionGen   │───>│ Test Loop        │                   │
-│  │ (random/directed)│    │ (test_cpu.py)    │                   │
-│  └──────────────────┘    └────────┬─────────┘                   │
-│                                   │                             │
-│  ┌──────────────────┐    ┌────────▼─────────┐    ┌────────────┐ │
-│  │ TestState        │<───│ CPUModel         │───>│ Encoders   │ │
-│  │ (expected vals)  │    │ (compute expect) │    │ (binary)   │ │
-│  └────────┬─────────┘    └──────────────────┘    └─────┬──────┘ │
-│           │                                            │        │
-│  ┌────────▼─────────┐                         ┌────────▼──────┐ │
-│  │ Monitors         │◄────────────────────────│ DUT           │ │
-│  │ (verify outputs) │                         │ (hardware)    │ │
-│  └──────────────────┘                         └───────────────┘ │
-└─────────────────────────────────────────────────────────────────┘
+Current CI combines block-level benches, directed machine-mode trap tests,
+and compiled applications. The [test infrastructure overview](../tests/README.md)
+also covers the ISA, torture, synthesis, and formal runners.
+
+The diagram below focuses on the legacy CPU reference harness in
+`test_cpu.py`. Its `cpu_random` target is CLI-only and still needs an OOO
+port: the fixed-latency expectation queues must become a commit-indexed
+scoreboard. It is not currently a passing regression for the OOO core.
+
+```mermaid
+flowchart TB
+    generator["InstructionGenerator<br/>Constrained-random parameters"]
+    loop["test_cpu.py<br/>Legacy CPU harness: OOO port pending"]
+    generator --> loop
+    loop --> encode["Instruction encoders"]
+    loop --> model["CPUModel<br/>Register, PC, and memory effects"]
+    encode -->|DUTInterface| dut["cpu_tb / cpu_ooo<br/>DUT execution"]
+    model --> state["TestState<br/>Expected-value queues"]
+    state --> registers["Integer / FP / PC monitors"]
+    state --> stores["MemoryModel store monitor<br/>Check only"]
+    dut -->|Observed outputs| registers
+    dut -->|Store address and data| stores
 ```
 
-1. Instruction generation produces random or directed parameters.
-2. The CPU model computes expected results.
-3. Encoders produce machine code.
-4. `TestState` queues the expected values.
-5. The DUT executes the instruction.
-6. Monitors compare DUT outputs with the queued expectations.
+The test loop encodes each instruction and separately computes its expected
+effects before driving the DUT. Monitors compare observed outputs with the
+queued expectations. The memory monitor checks stores; it does not drive
+read data or update the software memory model.
+
+`InstructionExecutor` offers the encode/model/queue/drive sequence as a
+reusable helper for directed tests. The current directed suites orchestrate
+their own instruction driving and checks. `directed_traps` runs in CI;
+`directed_atomics` and `compressed` are ported and remain CLI-only.
+`directed_multicycle` still needs an OOO port, like `cpu_random`.
 
 ### Design Under Test (DUT)
 
 The Frost CPU implements RV64GCB (G = IMAFD, plus C and B) with M, S, and U
-privilege modes. `verif/config.py` pins `XLEN` to 64 to match `riscv_pkg`, and
-every Python model and encoder imports it from there. See the
+privilege modes. `verif/config.py` pins `XLEN` to 64 to match `riscv_pkg`;
+the shared integer arithmetic and signedness helpers use that setting. See the
 [root README](../README.md) for the full ISA extension table.
 
 The DUT has:
@@ -49,16 +57,20 @@ The DUT has:
 
 ### Verification Methodology
 
-1. Constrained-random testing: thousands of generated instructions checked
-   against the software reference model (`test_cpu.py`).
-2. Directed testing: targeted scenarios for traps, atomics, compressed
-   instructions, and multi-cycle hazards (`test_directed_*.py`,
-   `test_compressed.py`).
+1. Block-level testing: directed and randomized benches check individual
+   pipeline, Tomasulo, cache, MMU, control, and debug modules.
+2. Directed CPU testing: `directed_traps` checks machine-mode traps and
+   interrupts in CI. The ported atomic and compressed suites remain CLI-only;
+   the multi-cycle suite still needs an OOO port.
 3. Real-program integration: complete compiled applications (Hello World,
-   CoreMark, CoreMark-PRO) run with pass/fail detection
-   (`test_real_program.py`).
-4. Coverage tracking: the random regression fails if any tracked instruction
-   type falls below a minimum execution count (`min_coverage_count`).
+   CoreMark, CoreMark-PRO) run with UART pass/fail detection
+   (`test_real_program.py`). These suites exercise the BRAM and cached DDR
+   tiers according to the runner's registry and tier exclusions.
+4. Legacy random CPU harness: `test_cpu.py` generates constrained-random
+   instructions and tracks a minimum execution count per instruction type
+   (`min_coverage_count`). Its fixed-latency scoreboard still needs an OOO
+   port; current ISA coverage comes from the riscv-tests, architecture
+   compliance, and real-program suites.
 
 ## Directory Structure
 
@@ -68,7 +80,7 @@ verif/
 ├── verification_types.py  # Type aliases for type safety
 ├── exceptions.py          # Custom exception hierarchy
 ├── cocotb_tests/          # Cocotb test cases
-│   ├── test_cpu.py        # Main random regression test
+│   ├── test_cpu.py        # Legacy random CPU harness (OOO port pending)
 │   ├── test_common.py     # Shared test utilities (TestConfig, branch flush)
 │   ├── test_directed_atomics.py  # LR.W/SC.W atomic operation tests
 │   ├── test_directed_traps.py    # ECALL, EBREAK, MRET, interrupt tests
@@ -108,7 +120,7 @@ verif/
 │   ├── compressed_encode.py   # RVC compressed (16-bit) encoders
 │   └── op_tables.py       # Instruction mapping tables
 ├── monitors/              # Runtime verification monitors
-│   └── monitors.py        # Register, PC, and memory monitors
+│   └── monitors.py        # Integer/FP register and PC monitors
 └── utils/                 # Utility functions
     ├── riscv_utils.py     # RISC-V data type utilities
     ├── memory_utils.py    # Memory alignment and address helpers
@@ -120,11 +132,13 @@ verif/
 
 ### Test Infrastructure (`/cocotb_tests`)
 
-#### Main CPU test (`test_cpu.py`)
+#### Legacy random CPU harness (`test_cpu.py`)
 
 Generates constrained-random instruction sequences and coordinates generation,
 modeling, and DUT driving. It manages the expected-value queues the monitors
-consume and handles pipeline effects (stalls, flushes, branch mispredictions).
+consume and models stalls and branch flushes with assumptions inherited from
+the in-order core. The `cpu_random` target is CLI-only until its scoreboard
+is ported to OOO commit events.
 
 - `run_random_regression()`: shared regression driver wrapped by the `@cocotb.test()` functions (`test_random_riscv_regression`, `test_random_riscv_regression_force_one_address`, and the FP variants)
 
@@ -191,11 +205,10 @@ BLT, BGE, BLTU, and BGEU, with signed or unsigned comparison as the operation
 requires.
 
 #### Memory Model (`memory_model.py`)
-Simulates the data memory interface:
-- Byte-addressable memory with configurable address width
+Keeps a software copy of the CPU harness's data memory:
+- Byte-addressable memory masked to `MEMORY_ADDRESS_WIDTH` in `config.py`
 - Byte, halfword, word, and doubleword accesses (the DUT's simulation data
   BRAM stores aligned 64-bit rows)
-- Store byte-enable generation
 - The `driver_and_monitor` coroutine checks DUT store traffic. Despite the
   name it drives nothing; `cpu_model.py` writes the memory image itself.
 
@@ -212,15 +225,17 @@ Maps each instruction mnemonic to its binary encoder, and to a software
 evaluator as well where the result is modeled (stores, branches, jumps, and
 fences need no evaluator). Tables are grouped by family (`R_ALU`, `I_ALU`,
 `LOADS`, `STORES`, `BRANCHES`, `JUMPS`, the `C_*` compressed tables, the `FP_*`
-tables) and cover every supported extension, driving both generation and result
-modeling.
+tables), driving generation and result modeling for the instructions the
+Python harness supports. These tables cover a subset of the CPU ISA; for
+example, the atomic tables contain word operations, and supervisor control
+instructions are exercised by other suites.
 
 ### Monitors (`/monitors`)
 
 `monitors.py` checks DUT outputs throughout the simulation:
-- `RegisterFileMonitor` and `FPRegisterFileMonitor` check every integer and FP
-  register write against the expected values
-- `ProgramCounterMonitor` checks control flow
+- `RegisterFileMonitor` and `FPRegisterFileMonitor` compare full register-file
+  snapshots when `o_vld` asserts (the integer comparison excludes x0)
+- `ProgramCounterMonitor` compares `o_pc` when `o_pc_vld` asserts
 - The memory interface monitor (`memory_model.driver_and_monitor`) checks store
   traffic only. Whenever the byte write-enable mask is non-zero it matches the
   DUT's address and data against the expected queues, and raises on an
@@ -247,7 +262,8 @@ modeling.
 
 ### Configuring a test
 
-Pass a `TestConfig` instance to the test:
+Pass a `TestConfig` instance to the legacy random harness. This configuration
+example describes its API; the OOO scoreboard port is still pending:
 
 ```python
 from cocotb_tests.test_common import TestConfig
@@ -305,7 +321,7 @@ Bare `make` in `tests/` builds the `Makefile` default (`TOPLEVEL=cpu_tb`,
 ```
 
 Run a single test function with `--testcase` (sets cocotb's
-`COCOTB_TEST_FILTER` to an exact match):
+`COCOTB_TEST_FILTER` to the supplied name or regex followed by `$`):
 ```bash
 ./scripts/frost.py cocotb directed_traps --testcase test_directed_trap_handling
 ./scripts/frost.py cocotb directed_atomics --testcase test_directed_lr_sc
@@ -319,12 +335,16 @@ Run integration tests with real programs (registry targets):
 
 ### Memory tier (BRAM vs cached DDR)
 
-Real-program tests run in two memory tiers. The default `bram` tier loads the
-whole program into low BRAM. Setting `FROST_COCOTB_MEM_CONFIG=ddr` relinks the
-program into the cached DDR region (`0x8000_0000`, behind the L1/L2 cache
-hierarchy) so it executes through the L1I fetch path and the D-side cache; the
-behavioral DDR model loads the program's `sw_ddr.mem` image. Both tiers run as
-separate CI jobs (the ddr job adds `-e FROST_COCOTB_MEM_CONFIG=ddr`).
+Real-program tests have two memory-tier settings. The default `bram` tier
+normally places code and data in low BRAM. Setting
+`FROST_COCOTB_MEM_CONFIG=ddr` selects linking into the cached DDR region
+(`0x8000_0000`, behind the L1/L2 cache hierarchy), exercising the L1I fetch
+path and the D-side cache; the behavioral DDR model loads `sw_ddr.mem`.
+Some apps keep dedicated DDR sections or heaps, force DDR linking, or use a
+fixed boot layout. For example, AMO and timer torture always use DDR, and
+OpenSBI smoke keeps its BRAM shim and DDR firmware regardless of the setting.
+CI selects tiers through `FROST_COCOTB_MEM_CONFIG` and runs fixed-layout
+OpenSBI smoke separately on the `bram` axis.
 
 ```bash
 FROST_COCOTB_MEM_CONFIG=ddr ./scripts/frost.py cocotb coremark
@@ -336,10 +356,11 @@ therefore forces `COCOTB_NUM_RUNS=1`; the bram tier keeps its two-run default,
 which checks that programs survive a reset. `*_fetch_fuzz` and `ddr_*` programs
 self-skip in the ddr tier.
 
-`test_real_program.py` honors two env knobs directly: `COCOTB_NUM_RUNS`
-(reset-and-rerun count, default 2) and `COCOTB_MAX_CYCLES` (timeout budget;
-CoreMark-style benchmarks, linux_boot, and amo_irq_torture have larger
-per-app defaults with their own env overrides).
+Common controls in `test_real_program.py` are `COCOTB_NUM_RUNS`
+(reset-and-rerun count, default 2) and `COCOTB_MAX_CYCLES` (the generic timeout
+budget). Application-specific budgets can take precedence: CoreMark-style
+benchmarks, Linux boot, AMO torture, and timer torture have their own timeout
+environment variables; several other directed apps use fixed larger budgets.
 
 ### Using another DUT hierarchy
 

--- a/verif/cocotb_tests/test_common.py
+++ b/verif/cocotb_tests/test_common.py
@@ -105,7 +105,7 @@ def handle_branch_flush(
     are discarded. The model stands in for them with a NOP, which adds 0 to
     x0, writes the hardwired-zero x0, and advances the PC by 4.
 
-    Pipeline Flush State Machine:
+    Legacy reference-model flush timeline:
         ┌─────────────────────────────────────────────────────────────┐
         │ Branch/jump taken in EX stage                               │
         │                                                             │
@@ -115,10 +115,11 @@ def handle_branch_flush(
         │ Cycle 3: All flags cleared             → Resume normal ops  │
         └─────────────────────────────────────────────────────────────┘
 
-    This reference model treats all branches and jumps (JAL, JALR,
-    conditional branches) as resolving at EX with a 3-cycle flush. The CPU
-    predicts branches and its flush timing varies, but the monitors'
-    expected-value queues line up with this simplified model.
+    This legacy reference model treats all branches and jumps (JAL, JALR,
+    conditional branches) as resolving at EX with a 3-cycle flush. The OOO
+    CPU has variable recovery and commit timing. The cpu_random harness
+    remains CLI-only and needs a commit-indexed scoreboard before its
+    expected-value queues can validate the current core.
 
     Args:
         state: Test state to update branch tracking


### PR DESCRIPTION
Replace ASCII architecture overviews with four shared SVG diagrams and five Mermaid workflows and state diagrams. Align the diagrams and surrounding documentation with the current RTL, FPGA loading flow, and verification coverage.

Validate SVG structure and references, render and visually inspect every diagram, check 78 local documentation links, and pass repository Docker lint. Confirm the Python edit changes only its docstring.